### PR TITLE
feat: add logo, favicon and update example app meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 <!-- @format -->
 
 <p align="center">
+  <img src="docs/images/logo.svg" alt="react-js-multi-range-sliders logo" width="96" height="96"/>
+</p>
+
+<p align="center">
   <img src="docs/images/banner.svg" alt="react-js-multi-range-sliders — 5 slider types, 4 themes, TypeScript, zero deps" width="768"/>
 </p>
 

--- a/docs/images/logo.svg
+++ b/docs/images/logo.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <linearGradient id="thumb-inner" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#e0f2fe"/>
+    </linearGradient>
+    <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%">
+      <feDropShadow dx="0" dy="3" stdDeviation="4" flood-color="#1e40af" flood-opacity="0.3"/>
+    </filter>
+  </defs>
+
+  <!-- Background card -->
+  <rect width="200" height="200" rx="40" fill="url(#bg)"/>
+
+  <!-- Subtle grid pattern overlay -->
+  <rect width="200" height="200" rx="40" fill="none" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+
+  <!-- Track (background) -->
+  <rect x="28" y="94" width="144" height="12" rx="6" fill="rgba(255,255,255,0.25)"/>
+
+  <!-- Range fill (min → max) -->
+  <rect x="58" y="94" width="76" height="12" rx="6" fill="rgba(255,255,255,0.9)"/>
+
+  <!-- Left thumb -->
+  <circle cx="58" cy="100" r="22" fill="url(#thumb-inner)" filter="url(#shadow)"/>
+  <circle cx="58" cy="100" r="12" fill="#2563eb"/>
+  <circle cx="58" cy="100" r="6"  fill="white"/>
+
+  <!-- Right thumb -->
+  <circle cx="134" cy="100" r="22" fill="url(#thumb-inner)" filter="url(#shadow)"/>
+  <circle cx="134" cy="100" r="12" fill="#0891b2"/>
+  <circle cx="134" cy="100" r="6"  fill="white"/>
+
+  <!-- Value labels -->
+  <text x="58"  y="148" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="16" font-weight="700" fill="rgba(255,255,255,0.7)">30</text>
+  <text x="134" y="148" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="16" font-weight="700" fill="rgba(255,255,255,0.7)">70</text>
+
+  <!-- Min / Max markers -->
+  <text x="28"  y="75" text-anchor="middle" font-family="system-ui,sans-serif" font-size="11" fill="rgba(255,255,255,0.45)">0</text>
+  <text x="172" y="75" text-anchor="middle" font-family="system-ui,sans-serif" font-size="11" fill="rgba(255,255,255,0.45)">100</text>
+</svg>

--- a/example/public/favicon.svg
+++ b/example/public/favicon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background rounded square -->
+  <rect width="32" height="32" rx="7" fill="url(#bg)"/>
+
+  <!-- Track -->
+  <rect x="5" y="14" width="22" height="4" rx="2" fill="rgba(255,255,255,0.3)"/>
+
+  <!-- Range fill between thumbs -->
+  <rect x="10" y="14" width="12" height="4" rx="1" fill="rgba(255,255,255,0.9)"/>
+
+  <!-- Left thumb -->
+  <circle cx="10" cy="16" r="5.5" fill="white"/>
+  <circle cx="10" cy="16" r="2.5" fill="#2563eb"/>
+
+  <!-- Right thumb -->
+  <circle cx="22" cy="16" r="5.5" fill="white"/>
+  <circle cx="22" cy="16" r="2.5" fill="#0891b2"/>
+</svg>

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -1,14 +1,19 @@
 <!doctype html>
 <html lang="en">
-
-<head>
+  <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>MultiRangeSlider Example</title>
-</head>
+    <meta name="theme-color" content="#2563eb" />
+    <meta
+      name="description"
+      content="Live examples for react-js-multi-range-sliders — single, dual-thumb, vertical, multi-point, and circular sliders with 4 themes and TypeScript support."
+    />
 
-<body>
+    <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/favicon.svg" />
+
+    <title>react-js-multi-range-sliders — Examples</title>
+  </head>
+  <body>
     <div id="root"></div>
-</body>
-
+  </body>
 </html>


### PR DESCRIPTION
- docs/images/logo.svg: 200×200 brand logo with blue→cyan gradient, dual-thumb track, inner dots — shown in README at 96px
- example/public/favicon.svg: 32×32 SVG favicon, same gradient, simplified for small sizes (works 16px → 192px)
- example/public/index.html: wire up favicon.svg, updated page title, added theme-color and description meta tags
- README.md: logo above banner image