### PR TITLE
feat(sliders): tooltip collision resolution + scale ruler/labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ function PriceFilter() {
 | `labelStyle` | `CSSProperties` | — | Inline style for labels |
 | `ariaLabelMin` | `string` | `"Minimum value"` | ARIA label, min thumb |
 | `ariaLabelMax` | `string` | `"Maximum value"` | ARIA label, max thumb |
+| `labels` | `string[]` | — | Evenly-spaced tick labels (e.g. day or month names) |
+| `ruler` | `boolean` | `true` when `labels` set | Show ruler tick marks below the track |
+| `subSteps` | `boolean \| number` | `false` | Minor ticks between major ticks (`true` = 3) |
 
 ---
 
@@ -165,7 +168,7 @@ import { SingleSlider } from "react-js-multi-range-sliders";
 />
 ```
 
-Same base props as `RangeSlider`. Additional prop:
+Same base props as `RangeSlider` (including `labels`, `ruler`, `subSteps`). Additional prop:
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
@@ -291,6 +294,155 @@ import { CircularSlider } from "react-js-multi-range-sliders";
 | `ariaLabel` | `string` | `"Circular slider"` | ARIA label |
 | `onChangeStart` | `(v: number) => void` | — | Fires on pointer-down |
 | `onChangeComplete` | `(v: number) => void` | — | Fires on pointer-up |
+
+---
+
+## Scale Slider — ruler, labels & subSteps
+
+`RangeSlider` and `SingleSlider` both support an optional ruler (tick marks) and an
+evenly-spaced label row below the track.
+
+<p align="center">
+  <img src="docs/images/demo-scale-simple.svg"   alt="Simple range with ruler" width="640"/><br/>
+  <img src="docs/images/demo-scale-weekdays.svg"  alt="Week-day labels" width="640"/><br/>
+  <img src="docs/images/demo-scale-daterange.svg" alt="Month labels for date range" width="640"/><br/>
+  <img src="docs/images/demo-scale-timerange.svg" alt="Time range with subSteps minor ticks" width="640"/><br/>
+  <img src="docs/images/demo-scale-negative.svg"  alt="Negative-to-positive range" width="640"/><br/>
+  <img src="docs/images/demo-scale-steponly.svg"  alt="Step-snapping range" width="640"/>
+</p>
+
+### Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `ruler` | `boolean` | `true` when `labels` set | Render tick marks below the track |
+| `labels` | `string[]` | — | Array of label strings placed at evenly-spaced positions |
+| `subSteps` | `boolean \| number` | `false` | Minor ticks between each pair of major ticks. `true` = 3 minor ticks (4 sub-divisions); any `number` uses that count explicitly |
+
+### Examples
+
+**1. Simple range with auto ruler**
+
+```tsx
+<RangeSlider
+  min={0} max={100}
+  defaultValue={{ min: 25, max: 75 }}
+  onChange={setRange}
+  ruler
+  showLabels
+/>
+```
+
+The `ruler` prop auto-generates up to 20 evenly-spaced major ticks based on
+`Math.min(20, (max - min) / step)`.
+
+---
+
+**2. Week-day range with named labels**
+
+```tsx
+const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+<RangeSlider
+  min={0} max={6} step={1}
+  defaultValue={{ min: 1, max: 5 }}
+  onChange={setWeekRange}
+  labels={DAYS}
+  formatLabel={(v) => DAYS[v]}   // tooltip and value display
+  showTooltip
+  showLabels={false}             // hide redundant number labels
+/>
+```
+
+`labels` sets both the ruler tick count and the text shown below each tick.
+Pair it with `formatLabel` to customise the tooltip / current-value text.
+
+---
+
+**3. Date range with month markers**
+
+```tsx
+const MONTHS = ["Jan","Feb","Mar","Apr","May","Jun",
+                "Jul","Aug","Sep","Oct","Nov","Dec"];
+
+<RangeSlider
+  min={0} max={365}
+  defaultValue={{ min: 22, max: 364 }}
+  onChange={setDateRange}
+  labels={MONTHS}
+  formatLabel={(v) => {
+    const date = new Date(2022, 0, v + 1);
+    return date.toLocaleDateString("en-GB", { day:"numeric", month:"short" });
+  }}
+  showTooltip
+  showLabels={false}
+/>
+```
+
+---
+
+**4. Time range with sub-step minor ticks**
+
+```tsx
+const HOURS = Array.from({ length: 13 }, (_, i) =>
+  String(i).padStart(2, "0") + ":00"
+);
+
+const fmtTime = (v: number) => {
+  const h = Math.floor(v / 60);
+  const m = v % 60;
+  return `${String(h).padStart(2,"0")}:${String(m).padStart(2,"0")}`;
+};
+
+<RangeSlider
+  min={0} max={719} step={1}
+  defaultValue={{ min: 619, max: 719 }}
+  onChange={setTimeRange}
+  labels={HOURS}
+  subSteps={true}          // 3 minor ticks per section = 15-min intervals
+  formatLabel={fmtTime}
+  showTooltip
+  showLabels={false}
+/>
+```
+
+`subSteps={true}` inserts 3 minor ticks (default) between each pair of major ticks.
+Pass a number to use a custom count, e.g. `subSteps={1}` for half-way ticks.
+
+---
+
+**5. Negative / positive range**
+
+```tsx
+<RangeSlider
+  min={-1} max={1} step={0.1}
+  defaultValue={{ min: -0.5, max: 0.5 }}
+  onChange={setRange}
+  ruler
+  showLabels
+  formatLabel={(v) => v.toFixed(1)}
+/>
+```
+
+The ruler works across negative ranges. `step={0.1}` → 20 auto major ticks.
+
+---
+
+**6. Step-snapping range**
+
+```tsx
+<RangeSlider
+  min={0} max={100} step={5}
+  defaultValue={{ min: 30, max: 60 }}
+  onChange={setRange}
+  ruler
+  showLabels
+/>
+```
+
+The ruler tick count adjusts to the step size automatically:
+`sections = Math.min(20, (100 - 0) / 5)` = 20 sections → 21 ticks at 0, 5, 10 … 100.
+Native `<input type="range" step="5">` enforces the snapping.
 
 ---
 

--- a/docs/images/demo-scale-daterange.svg
+++ b/docs/images/demo-scale-daterange.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="85" viewBox="0 0 640 85">
+  <rect width="640" height="85" fill="#f8fafc" rx="8"/>
+
+  <!-- Track (30→610, w=580) -->
+  <rect x="30" y="29" width="580" height="4" rx="2" fill="#dde3ea"/>
+  <!-- Range fill: day 22 (6%)=65 → day 364 (99.7%)=608 -->
+  <rect x="65" y="29" width="543" height="4" fill="#4a9a4a"/>
+
+  <!-- Thumbs: day 22 cx=65, day 364 cx=608 -->
+  <circle cx="65"  cy="31" r="9" fill="white" stroke="#4a9a4a" stroke-width="2.5"/>
+  <circle cx="608" cy="31" r="9" fill="white" stroke="#4a9a4a" stroke-width="2.5"/>
+
+  <!--
+    Ruler: 12 major ticks for 11 intervals (months), spacing=580/11≈52.7px
+    Positions: 30, 83, 135, 188, 241, 294, 346, 399, 452, 505, 557, 610
+  -->
+  <g stroke="#64748b" stroke-width="1" opacity="0.55">
+    <line x1="30"  y1="43" x2="30"  y2="51"/>
+    <line x1="83"  y1="43" x2="83"  y2="51"/>
+    <line x1="135" y1="43" x2="135" y2="51"/>
+    <line x1="188" y1="43" x2="188" y2="51"/>
+    <line x1="241" y1="43" x2="241" y2="51"/>
+    <line x1="294" y1="43" x2="294" y2="51"/>
+    <line x1="346" y1="43" x2="346" y2="51"/>
+    <line x1="399" y1="43" x2="399" y2="51"/>
+    <line x1="452" y1="43" x2="452" y2="51"/>
+    <line x1="505" y1="43" x2="505" y2="51"/>
+    <line x1="557" y1="43" x2="557" y2="51"/>
+    <line x1="610" y1="43" x2="610" y2="51"/>
+  </g>
+
+  <!-- Scale labels: Jan … Dec -->
+  <text x="30"  y="65" font-family="system-ui,-apple-system,sans-serif" font-size="10" fill="#64748b">Jan</text>
+  <text x="83"  y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="10" fill="#64748b">Feb</text>
+  <text x="135" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="10" fill="#64748b">Mar</text>
+  <text x="188" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="10" fill="#64748b">Apr</text>
+  <text x="241" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="10" fill="#64748b">May</text>
+  <text x="294" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="10" fill="#64748b">Jun</text>
+  <text x="346" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="10" fill="#64748b">Jul</text>
+  <text x="399" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="10" fill="#64748b">Aug</text>
+  <text x="452" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="10" fill="#64748b">Sep</text>
+  <text x="505" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="10" fill="#64748b">Oct</text>
+  <text x="557" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="10" fill="#64748b">Nov</text>
+  <text x="610" y="65" text-anchor="end"    font-family="system-ui,-apple-system,sans-serif" font-size="10" fill="#64748b">Dec</text>
+</svg>

--- a/docs/images/demo-scale-negative.svg
+++ b/docs/images/demo-scale-negative.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="88" viewBox="0 0 640 88">
+  <rect width="640" height="88" fill="#f8fafc" rx="8"/>
+
+  <!-- Track (30→610, w=580) -->
+  <rect x="30" y="36" width="580" height="4" rx="2" fill="#dde3ea"/>
+  <!--
+    Range fill: min=-1 max=1 step=0.1
+    -0.5 → 25% → x=175    0.5 → 75% → x=465
+  -->
+  <rect x="175" y="36" width="290" height="4" fill="#4a9a4a"/>
+
+  <!-- Thumbs -->
+  <circle cx="175" cy="38" r="9" fill="white" stroke="#4a9a4a" stroke-width="2.5"/>
+  <circle cx="465" cy="38" r="9" fill="white" stroke="#4a9a4a" stroke-width="2.5"/>
+
+  <!--
+    Ruler: 21 major ticks, spacing=29px
+    (max-min)/step = 2/0.1 = 20 sections → 21 ticks, same positions as simple demo)
+  -->
+  <g stroke="#64748b" stroke-width="1">
+    <line x1="30"  y1="49" x2="30"  y2="57" opacity="0.55"/>
+    <line x1="59"  y1="49" x2="59"  y2="57" opacity="0.55"/>
+    <line x1="88"  y1="49" x2="88"  y2="57" opacity="0.55"/>
+    <line x1="117" y1="49" x2="117" y2="57" opacity="0.55"/>
+    <line x1="146" y1="49" x2="146" y2="57" opacity="0.55"/>
+    <line x1="175" y1="49" x2="175" y2="57" opacity="0.55"/>
+    <line x1="204" y1="49" x2="204" y2="57" opacity="0.55"/>
+    <line x1="233" y1="49" x2="233" y2="57" opacity="0.55"/>
+    <line x1="262" y1="49" x2="262" y2="57" opacity="0.55"/>
+    <line x1="291" y1="49" x2="291" y2="57" opacity="0.55"/>
+    <line x1="320" y1="49" x2="320" y2="57" opacity="0.55"/>
+    <line x1="349" y1="49" x2="349" y2="57" opacity="0.55"/>
+    <line x1="378" y1="49" x2="378" y2="57" opacity="0.55"/>
+    <line x1="407" y1="49" x2="407" y2="57" opacity="0.55"/>
+    <line x1="436" y1="49" x2="436" y2="57" opacity="0.55"/>
+    <line x1="465" y1="49" x2="465" y2="57" opacity="0.55"/>
+    <line x1="494" y1="49" x2="494" y2="57" opacity="0.55"/>
+    <line x1="523" y1="49" x2="523" y2="57" opacity="0.55"/>
+    <line x1="552" y1="49" x2="552" y2="57" opacity="0.55"/>
+    <line x1="581" y1="49" x2="581" y2="57" opacity="0.55"/>
+    <line x1="610" y1="49" x2="610" y2="57" opacity="0.55"/>
+  </g>
+
+  <!-- Min / max labels -->
+  <text x="30"  y="73" font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#94a3b8">-1</text>
+  <text x="610" y="73" text-anchor="end" font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#94a3b8">1</text>
+</svg>

--- a/docs/images/demo-scale-simple.svg
+++ b/docs/images/demo-scale-simple.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="88" viewBox="0 0 640 88">
+  <rect width="640" height="88" fill="#f8fafc" rx="8"/>
+
+  <!-- Track (30→610, w=580) -->
+  <rect x="30" y="36" width="580" height="4" rx="2" fill="#dde3ea"/>
+  <!-- Range fill: 25%=175 → 75%=465 -->
+  <rect x="175" y="36" width="290" height="4" fill="#4a9a4a"/>
+
+  <!-- Thumbs -->
+  <circle cx="175" cy="38" r="9" fill="white" stroke="#4a9a4a" stroke-width="2.5"/>
+  <circle cx="465" cy="38" r="9" fill="white" stroke="#4a9a4a" stroke-width="2.5"/>
+
+  <!-- Ruler: 21 major ticks, spacing=29px (20 sections for min=0 max=100 step=1 → cap 20) -->
+  <g stroke="#64748b" stroke-width="1">
+    <line x1="30"  y1="49" x2="30"  y2="57" opacity="0.55"/>
+    <line x1="59"  y1="49" x2="59"  y2="57" opacity="0.55"/>
+    <line x1="88"  y1="49" x2="88"  y2="57" opacity="0.55"/>
+    <line x1="117" y1="49" x2="117" y2="57" opacity="0.55"/>
+    <line x1="146" y1="49" x2="146" y2="57" opacity="0.55"/>
+    <line x1="175" y1="49" x2="175" y2="57" opacity="0.55"/>
+    <line x1="204" y1="49" x2="204" y2="57" opacity="0.55"/>
+    <line x1="233" y1="49" x2="233" y2="57" opacity="0.55"/>
+    <line x1="262" y1="49" x2="262" y2="57" opacity="0.55"/>
+    <line x1="291" y1="49" x2="291" y2="57" opacity="0.55"/>
+    <line x1="320" y1="49" x2="320" y2="57" opacity="0.55"/>
+    <line x1="349" y1="49" x2="349" y2="57" opacity="0.55"/>
+    <line x1="378" y1="49" x2="378" y2="57" opacity="0.55"/>
+    <line x1="407" y1="49" x2="407" y2="57" opacity="0.55"/>
+    <line x1="436" y1="49" x2="436" y2="57" opacity="0.55"/>
+    <line x1="465" y1="49" x2="465" y2="57" opacity="0.55"/>
+    <line x1="494" y1="49" x2="494" y2="57" opacity="0.55"/>
+    <line x1="523" y1="49" x2="523" y2="57" opacity="0.55"/>
+    <line x1="552" y1="49" x2="552" y2="57" opacity="0.55"/>
+    <line x1="581" y1="49" x2="581" y2="57" opacity="0.55"/>
+    <line x1="610" y1="49" x2="610" y2="57" opacity="0.55"/>
+  </g>
+
+  <!-- Min / max labels -->
+  <text x="30"  y="73" font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#94a3b8">0</text>
+  <text x="610" y="73" text-anchor="end" font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#94a3b8">100</text>
+</svg>

--- a/docs/images/demo-scale-steponly.svg
+++ b/docs/images/demo-scale-steponly.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="88" viewBox="0 0 640 88">
+  <rect width="640" height="88" fill="#f8fafc" rx="8"/>
+
+  <!-- Track (30→610, w=580) -->
+  <rect x="30" y="36" width="580" height="4" rx="2" fill="#dde3ea"/>
+  <!--
+    Range fill: min=0 max=100 step=5
+    30% → x=204    60% → x=378
+  -->
+  <rect x="204" y="36" width="174" height="4" fill="#4a9a4a"/>
+
+  <!-- Thumbs -->
+  <circle cx="204" cy="38" r="9" fill="white" stroke="#4a9a4a" stroke-width="2.5"/>
+  <circle cx="378" cy="38" r="9" fill="white" stroke="#4a9a4a" stroke-width="2.5"/>
+
+  <!--
+    Ruler: 21 major ticks, spacing=29px
+    (max-min)/step = 100/5 = 20 sections → 21 ticks (same positions as simple demo)
+  -->
+  <g stroke="#64748b" stroke-width="1">
+    <line x1="30"  y1="49" x2="30"  y2="57" opacity="0.55"/>
+    <line x1="59"  y1="49" x2="59"  y2="57" opacity="0.55"/>
+    <line x1="88"  y1="49" x2="88"  y2="57" opacity="0.55"/>
+    <line x1="117" y1="49" x2="117" y2="57" opacity="0.55"/>
+    <line x1="146" y1="49" x2="146" y2="57" opacity="0.55"/>
+    <line x1="175" y1="49" x2="175" y2="57" opacity="0.55"/>
+    <line x1="204" y1="49" x2="204" y2="57" opacity="0.55"/>
+    <line x1="233" y1="49" x2="233" y2="57" opacity="0.55"/>
+    <line x1="262" y1="49" x2="262" y2="57" opacity="0.55"/>
+    <line x1="291" y1="49" x2="291" y2="57" opacity="0.55"/>
+    <line x1="320" y1="49" x2="320" y2="57" opacity="0.55"/>
+    <line x1="349" y1="49" x2="349" y2="57" opacity="0.55"/>
+    <line x1="378" y1="49" x2="378" y2="57" opacity="0.55"/>
+    <line x1="407" y1="49" x2="407" y2="57" opacity="0.55"/>
+    <line x1="436" y1="49" x2="436" y2="57" opacity="0.55"/>
+    <line x1="465" y1="49" x2="465" y2="57" opacity="0.55"/>
+    <line x1="494" y1="49" x2="494" y2="57" opacity="0.55"/>
+    <line x1="523" y1="49" x2="523" y2="57" opacity="0.55"/>
+    <line x1="552" y1="49" x2="552" y2="57" opacity="0.55"/>
+    <line x1="581" y1="49" x2="581" y2="57" opacity="0.55"/>
+    <line x1="610" y1="49" x2="610" y2="57" opacity="0.55"/>
+  </g>
+
+  <!-- Min / max labels -->
+  <text x="30"  y="73" font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#94a3b8">0</text>
+  <text x="610" y="73" text-anchor="end" font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#94a3b8">100</text>
+</svg>

--- a/docs/images/demo-scale-timerange.svg
+++ b/docs/images/demo-scale-timerange.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="88" viewBox="0 0 640 88">
+  <rect width="640" height="88" fill="#f8fafc" rx="8"/>
+
+  <!-- Track (30→610, w=580) -->
+  <rect x="30" y="29" width="580" height="4" rx="2" fill="#dde3ea"/>
+  <!-- Range fill: 619/719=86.1% (cx≈530) → 719/719=100% (cx=610) -->
+  <rect x="530" y="29" width="80" height="4" fill="#4a9a4a"/>
+
+  <!-- Thumbs: 10:19 cx=530, 12:00 cx=610 -->
+  <circle cx="530" cy="31" r="9" fill="white" stroke="#4a9a4a" stroke-width="2.5"/>
+  <circle cx="610" cy="31" r="9" fill="white" stroke="#4a9a4a" stroke-width="2.5"/>
+
+  <!--
+    Ruler: 13 major ticks for 12 intervals (00:00–12:00), spacing=580/12≈48.3px
+    + 3 minor ticks per interval (at ¼ ½ ¾ = spacing/4≈12.1px apart)
+  -->
+
+  <!-- Major ticks (y1=43 y2=51, 8px) -->
+  <g stroke="#64748b" stroke-width="1" opacity="0.55">
+    <line x1="30"  y1="43" x2="30"  y2="51"/>
+    <line x1="78"  y1="43" x2="78"  y2="51"/>
+    <line x1="127" y1="43" x2="127" y2="51"/>
+    <line x1="175" y1="43" x2="175" y2="51"/>
+    <line x1="223" y1="43" x2="223" y2="51"/>
+    <line x1="272" y1="43" x2="272" y2="51"/>
+    <line x1="320" y1="43" x2="320" y2="51"/>
+    <line x1="368" y1="43" x2="368" y2="51"/>
+    <line x1="417" y1="43" x2="417" y2="51"/>
+    <line x1="465" y1="43" x2="465" y2="51"/>
+    <line x1="513" y1="43" x2="513" y2="51"/>
+    <line x1="562" y1="43" x2="562" y2="51"/>
+    <line x1="610" y1="43" x2="610" y2="51"/>
+  </g>
+
+  <!-- Minor ticks (y1=47 y2=51, 4px, opacity=0.30) -->
+  <g stroke="#64748b" stroke-width="1" opacity="0.30">
+    <!-- 00→01 --> <line x1="42"  y1="47" x2="42"  y2="51"/> <line x1="54"  y1="47" x2="54"  y2="51"/> <line x1="66"  y1="47" x2="66"  y2="51"/>
+    <!-- 01→02 --> <line x1="90"  y1="47" x2="90"  y2="51"/> <line x1="102" y1="47" x2="102" y2="51"/> <line x1="114" y1="47" x2="114" y2="51"/>
+    <!-- 02→03 --> <line x1="139" y1="47" x2="139" y2="51"/> <line x1="151" y1="47" x2="151" y2="51"/> <line x1="163" y1="47" x2="163" y2="51"/>
+    <!-- 03→04 --> <line x1="187" y1="47" x2="187" y2="51"/> <line x1="199" y1="47" x2="199" y2="51"/> <line x1="211" y1="47" x2="211" y2="51"/>
+    <!-- 04→05 --> <line x1="235" y1="47" x2="235" y2="51"/> <line x1="247" y1="47" x2="247" y2="51"/> <line x1="259" y1="47" x2="259" y2="51"/>
+    <!-- 05→06 --> <line x1="284" y1="47" x2="284" y2="51"/> <line x1="296" y1="47" x2="296" y2="51"/> <line x1="308" y1="47" x2="308" y2="51"/>
+    <!-- 06→07 --> <line x1="332" y1="47" x2="332" y2="51"/> <line x1="344" y1="47" x2="344" y2="51"/> <line x1="356" y1="47" x2="356" y2="51"/>
+    <!-- 07→08 --> <line x1="380" y1="47" x2="380" y2="51"/> <line x1="392" y1="47" x2="392" y2="51"/> <line x1="404" y1="47" x2="404" y2="51"/>
+    <!-- 08→09 --> <line x1="429" y1="47" x2="429" y2="51"/> <line x1="441" y1="47" x2="441" y2="51"/> <line x1="453" y1="47" x2="453" y2="51"/>
+    <!-- 09→10 --> <line x1="477" y1="47" x2="477" y2="51"/> <line x1="489" y1="47" x2="489" y2="51"/> <line x1="501" y1="47" x2="501" y2="51"/>
+    <!-- 10→11 --> <line x1="525" y1="47" x2="525" y2="51"/> <line x1="537" y1="47" x2="537" y2="51"/> <line x1="549" y1="47" x2="549" y2="51"/>
+    <!-- 11→12 --> <line x1="574" y1="47" x2="574" y2="51"/> <line x1="586" y1="47" x2="586" y2="51"/> <line x1="598" y1="47" x2="598" y2="51"/>
+  </g>
+
+  <!-- Scale labels: 00:00 … 12:00 (font-size=9 to fit 48px slots) -->
+  <text x="30"  y="63" font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">00:00</text>
+  <text x="78"  y="63" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">01:00</text>
+  <text x="127" y="63" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">02:00</text>
+  <text x="175" y="63" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">03:00</text>
+  <text x="223" y="63" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">04:00</text>
+  <text x="272" y="63" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">05:00</text>
+  <text x="320" y="63" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">06:00</text>
+  <text x="368" y="63" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">07:00</text>
+  <text x="417" y="63" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">08:00</text>
+  <text x="465" y="63" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">09:00</text>
+  <text x="513" y="63" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">10:00</text>
+  <text x="562" y="63" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">11:00</text>
+  <text x="610" y="63" text-anchor="end"    font-family="system-ui,-apple-system,sans-serif" font-size="9" fill="#64748b">12:00</text>
+</svg>

--- a/docs/images/demo-scale-weekdays.svg
+++ b/docs/images/demo-scale-weekdays.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="85" viewBox="0 0 640 85">
+  <rect width="640" height="85" fill="#f8fafc" rx="8"/>
+
+  <!-- Track (30→610, w=580) -->
+  <rect x="30" y="29" width="580" height="4" rx="2" fill="#dde3ea"/>
+  <!-- Range fill: Mon(1/6)=127 → Fri(5/6)=513 -->
+  <rect x="127" y="29" width="386" height="4" fill="#4a9a4a"/>
+
+  <!-- Thumbs: Mon cx=127, Fri cx=513 -->
+  <circle cx="127" cy="31" r="9" fill="white" stroke="#4a9a4a" stroke-width="2.5"/>
+  <circle cx="513" cy="31" r="9" fill="white" stroke="#4a9a4a" stroke-width="2.5"/>
+
+  <!-- Ruler: 7 major ticks at label positions (6 intervals, spacing≈96.7px) -->
+  <g stroke="#64748b" stroke-width="1" opacity="0.55">
+    <line x1="30"  y1="43" x2="30"  y2="51"/>
+    <line x1="127" y1="43" x2="127" y2="51"/>
+    <line x1="223" y1="43" x2="223" y2="51"/>
+    <line x1="320" y1="43" x2="320" y2="51"/>
+    <line x1="417" y1="43" x2="417" y2="51"/>
+    <line x1="513" y1="43" x2="513" y2="51"/>
+    <line x1="610" y1="43" x2="610" y2="51"/>
+  </g>
+
+  <!-- Scale labels: Sun Mon Tue Wed Thu Fri Sat -->
+  <text x="30"  y="65" font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#64748b">Sun</text>
+  <text x="127" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#64748b">Mon</text>
+  <text x="223" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#64748b">Tue</text>
+  <text x="320" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#64748b">Wed</text>
+  <text x="417" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#64748b">Thu</text>
+  <text x="513" y="65" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#64748b">Fri</text>
+  <text x="610" y="65" text-anchor="end"    font-family="system-ui,-apple-system,sans-serif" font-size="11" fill="#64748b">Sat</text>
+</svg>

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -74,6 +74,14 @@ export default function App() {
   const [progress, setProgress] = useState(65);
   const [knob, setKnob]         = useState(300);
 
+  /* Scale / ruler demo states */
+  const [simpleRange,   setSimpleRange]   = useState({ min: 25, max: 75 });
+  const [weekRange,     setWeekRange]     = useState({ min: 1,  max: 5  });
+  const [dateRange,     setDateRange]     = useState({ min: 22, max: 364 });
+  const [timeRange,     setTimeRange]     = useState({ min: 619, max: 719 });
+  const [negRange,      setNegRange]      = useState({ min: -0.5, max: 0.5 });
+  const [stepRange,     setStepRange]     = useState({ min: 30, max: 60 });
+
   /* Theme demo states */
   const [tDefault,  setTDefault]  = useState({ min: 25, max: 75 });
   const [tMaterial, setTMaterial] = useState({ min: 20, max: 80 });
@@ -684,6 +692,247 @@ import RangeSlider from "react-js-multi-range-sliders/RangeSlider";`}
   theme="neumorphic"  // "default" | "material" | "neumorphic" | "dark"
 />`}</CodeBlock>
         </section>
+      </div>
+
+      {/* ══════════════════════════════════════════════════════════
+          SCALE SLIDER — ruler + labels + subSteps
+      ══════════════════════════════════════════════════════════ */}
+      <div className="examples-layout" id="scale-slider">
+        <SectionHeader
+          tag="Feature"
+          title="Scale Slider"
+          description="Add a ruler and/or evenly-spaced labels below any slider using the labels, ruler, and subSteps props."
+        />
+
+        {/* 1 ── Simple range with auto ruler */}
+        <DemoSection
+          id="scale-simple"
+          title="Simple range slider with default values"
+          description="ruler automatically generates 20 evenly-spaced tick marks. No custom labels needed."
+          meta={<strong>onInput: &nbsp;{simpleRange.min} &nbsp; {simpleRange.max}</strong>}
+          code={`<RangeSlider
+  min={0} max={100}
+  defaultValue={{ min: 25, max: 75 }}
+  onChange={setSimpleRange}
+  ruler
+  showLabels
+/>`}
+        >
+          <RangeSlider
+            min={0} max={100}
+            defaultValue={{ min: 25, max: 75 }}
+            onChange={setSimpleRange}
+            ruler
+            showLabels
+            trackColor="#dde3ea"
+            rangeColor="#4a9a4a"
+            thumbColor="#ffffff"
+            style={{ width: "100%" }}
+          />
+        </DemoSection>
+
+        {/* 2 ── Week days */}
+        <DemoSection
+          id="scale-weekdays"
+          title="Range slider for week days"
+          description="Provide a labels array to render named tick positions. formatLabel maps the index to its label."
+          meta={<strong>onInput: &nbsp;{weekRange.min}:{["Sun","Mon","Tue","Wed","Thu","Fri","Sat"][weekRange.min]} &nbsp; {weekRange.max}:{["Sun","Mon","Tue","Wed","Thu","Fri","Sat"][weekRange.max]}</strong>}
+          code={`const DAYS = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
+
+<RangeSlider
+  min={0} max={6} step={1}
+  defaultValue={{ min: 1, max: 5 }}
+  onChange={setWeekRange}
+  labels={DAYS}
+  formatLabel={(v) => DAYS[v]}
+  showTooltip
+  showLabels={false}
+/>`}
+        >
+          {(() => {
+            const DAYS = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
+            return (
+              <RangeSlider
+                min={0} max={6} step={1}
+                defaultValue={{ min: 1, max: 5 }}
+                onChange={setWeekRange}
+                labels={DAYS}
+                formatLabel={(v) => DAYS[v]}
+                showTooltip
+                showLabels={false}
+                trackColor="#dde3ea"
+                rangeColor="#4a9a4a"
+                thumbColor="#ffffff"
+                style={{ width: "100%" }}
+              />
+            );
+          })()}
+        </DemoSection>
+
+        {/* 3 ── Date range */}
+        <DemoSection
+          id="scale-daterange"
+          title="Range slider for date range"
+          description="Month labels with a custom formatLabel that converts a day-of-year index to a human-readable date."
+          meta={<strong>onInput: &nbsp;{dateRange.min} &nbsp; {dateRange.max}</strong>}
+          code={`const MONTHS = ["Jan","Feb","Mar","Apr","May","Jun",
+                 "Jul","Aug","Sep","Oct","Nov","Dec"];
+
+// Simple day-of-year → month label helper
+const dayLabel = (d) => {
+  const mDays = [31,31,28,31,30,31,30,31,31,30,31,30,31];
+  let acc = 0;
+  for (let m = 0; m < 12; m++) {
+    acc += mDays[m];
+    if (d <= acc) return MONTHS[m];
+  }
+  return "Dec";
+};
+
+<RangeSlider
+  min={0} max={365}
+  defaultValue={{ min: 22, max: 364 }}
+  onChange={setDateRange}
+  labels={MONTHS}
+  formatLabel={dayLabel}
+  showTooltip
+  showLabels={false}
+/>`}
+        >
+          {(() => {
+            const MONTHS = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+            const mDays  = [31,31,28,31,30,31,30,31,31,30,31,30,31];
+            const dayLabel = (d) => {
+              let acc = 0;
+              for (let m = 0; m < 12; m++) { acc += mDays[m]; if (d <= acc) return MONTHS[m]; }
+              return "Dec";
+            };
+            return (
+              <RangeSlider
+                min={0} max={365}
+                defaultValue={{ min: 22, max: 364 }}
+                onChange={setDateRange}
+                labels={MONTHS}
+                formatLabel={dayLabel}
+                showTooltip
+                showLabels={false}
+                trackColor="#dde3ea"
+                rangeColor="#4a9a4a"
+                thumbColor="#ffffff"
+                style={{ width: "100%" }}
+              />
+            );
+          })()}
+        </DemoSection>
+
+        {/* 4 ── Time range with subSteps */}
+        <DemoSection
+          id="scale-time"
+          title="Time-Range with subSteps"
+          description="subSteps={true} inserts 3 minor ticks between each hour label (15-minute intervals)."
+          meta={<strong>onInput: &nbsp;{Math.floor(timeRange.min/60)}:{String(timeRange.min%60).padStart(2,"0")} &nbsp; {Math.floor(timeRange.max/60)}:{String(timeRange.max%60).padStart(2,"0")}</strong>}
+          code={`const HOURS = Array.from({ length: 13 }, (_, i) =>
+  String(i).padStart(2,"0") + ":00"
+);
+
+const fmtTime = (v) => {
+  const h = Math.floor(v / 60);
+  const m = v % 60;
+  return \`\${String(h).padStart(2,"0")}:\${String(m).padStart(2,"0")}\`;
+};
+
+<RangeSlider
+  min={0} max={719} step={1}
+  defaultValue={{ min: 619, max: 719 }}
+  onChange={setTimeRange}
+  labels={HOURS}
+  subSteps={true}
+  formatLabel={fmtTime}
+  showTooltip
+  showLabels={false}
+/>`}
+        >
+          {(() => {
+            const HOURS = Array.from({ length: 13 }, (_, i) => String(i).padStart(2,"0") + ":00");
+            const fmtTime = (v) => {
+              const h = Math.floor(v / 60);
+              const m = v % 60;
+              return `${String(h).padStart(2,"0")}:${String(m).padStart(2,"0")}`;
+            };
+            return (
+              <RangeSlider
+                min={0} max={719} step={1}
+                defaultValue={{ min: 619, max: 719 }}
+                onChange={setTimeRange}
+                labels={HOURS}
+                subSteps={true}
+                formatLabel={fmtTime}
+                showTooltip
+                showLabels={false}
+                trackColor="#dde3ea"
+                rangeColor="#4a9a4a"
+                thumbColor="#ffffff"
+                style={{ width: "100%" }}
+              />
+            );
+          })()}
+        </DemoSection>
+
+        {/* 5 ── Negative / positive range */}
+        <DemoSection
+          id="scale-negative"
+          title="Negative and positive range"
+          description="The ruler works across negative ranges. step={0.1} gives 20 auto ticks between -1 and 1."
+          meta={<strong>onInput: &nbsp;{negRange.min.toFixed(1)} &nbsp; {negRange.max.toFixed(1)}</strong>}
+          code={`<RangeSlider
+  min={-1} max={1} step={0.1}
+  defaultValue={{ min: -0.5, max: 0.5 }}
+  onChange={setNegRange}
+  ruler
+  showLabels
+  formatLabel={(v) => v.toFixed(1)}
+/>`}
+        >
+          <RangeSlider
+            min={-1} max={1} step={0.1}
+            defaultValue={{ min: -0.5, max: 0.5 }}
+            onChange={setNegRange}
+            ruler
+            showLabels
+            formatLabel={(v) => v.toFixed(1)}
+            trackColor="#dde3ea"
+            rangeColor="#4a9a4a"
+            thumbColor="#ffffff"
+            style={{ width: "100%" }}
+          />
+        </DemoSection>
+
+        {/* 6 ── Step-only snapping */}
+        <DemoSection
+          id="scale-steponly"
+          title="Range slider with step snapping"
+          description="step={5} snaps the thumbs to multiples of 5. The ruler tick count auto-adjusts to the step size."
+          meta={<strong>onInput: &nbsp;{stepRange.min} &nbsp; {stepRange.max}</strong>}
+          code={`<RangeSlider
+  min={0} max={100} step={5}
+  defaultValue={{ min: 30, max: 60 }}
+  onChange={setStepRange}
+  ruler
+  showLabels
+/>`}
+        >
+          <RangeSlider
+            min={0} max={100} step={5}
+            defaultValue={{ min: 30, max: 60 }}
+            onChange={setStepRange}
+            ruler
+            showLabels
+            trackColor="#dde3ea"
+            rangeColor="#4a9a4a"
+            thumbColor="#ffffff"
+            style={{ width: "100%" }}
+          />
+        </DemoSection>
       </div>
 
       {/* ══════════════════════════════════════════════════════════

--- a/src/components/MultiPointSlider.tsx
+++ b/src/components/MultiPointSlider.tsx
@@ -1,8 +1,9 @@
 import React, { memo, useCallback, useEffect, useId, useRef, useState } from "react";
 import type { MultiPointSliderProps } from "../types";
 import { cx } from "../utils/cx";
-import { clamp, thumbOffset, toPercent } from "../utils/percent";
+import { clamp, toPercent } from "../utils/percent";
 import { useChangeListeners } from "../hooks/useChangeListeners";
+import { useTooltipLayout } from "../hooks/useTooltipLayout";
 import "../styles/index.css";
 
 const MultiPointSlider = memo<MultiPointSliderProps>(function MultiPointSlider({
@@ -74,6 +75,10 @@ const MultiPointSlider = memo<MultiPointSliderProps>(function MultiPointSlider({
     width: Math.max(getPercent(current[i + 1]) - getPercent(v), 0),
   }));
 
+  const tipPercents = current.map(v => getPercent(v));
+  const tipLabels   = current.map(v => fmt(v));
+  const { slots: tipSlots, containerRef: tipContainerRef } = useTooltipLayout(tipPercents, tipLabels);
+
   return (
     <div
       role="group"
@@ -86,19 +91,14 @@ const MultiPointSlider = memo<MultiPointSliderProps>(function MultiPointSlider({
       </span>
 
       {showTooltip && (
-        <div className="mrs-tooltips" aria-hidden="true">
-          {current.map((v, i) => {
-            const p = getPercent(v);
-            return (
-              <span
-                key={i}
-                className="mrs-tooltip"
-                style={{ left: `calc(${p}% + ${thumbOffset(p)}px)` }}
-              >
-                {fmt(v)}
+        <div ref={tipContainerRef} className="mrs-tooltips" aria-hidden="true">
+          {tipSlots.map((slot, i) =>
+            slot.visible ? (
+              <span key={i} className="mrs-tooltip" style={{ left: slot.left }}>
+                {slot.label}
               </span>
-            );
-          })}
+            ) : null
+          )}
         </div>
       )}
 

--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -8,8 +8,10 @@ import React, {
 } from "react";
 import type { RangeSliderProps, RangeValue } from "../types";
 import { cx } from "../utils/cx";
-import { clamp, thumbOffset, toPercent } from "../utils/percent";
+import { clamp, toPercent } from "../utils/percent";
 import { useChangeListeners } from "../hooks/useChangeListeners";
+import { useTooltipLayout } from "../hooks/useTooltipLayout";
+import SliderScale from "./SliderScale";
 import "../styles/index.css";
 
 const RangeSlider = memo<RangeSliderProps>(function RangeSlider({
@@ -39,6 +41,9 @@ const RangeSlider = memo<RangeSliderProps>(function RangeSlider({
   showTooltip = false,
   showLabels = true,
   formatLabel,
+  labels,
+  ruler,
+  subSteps,
   ariaLabelMin,
   ariaLabelMax,
 }) {
@@ -105,6 +110,19 @@ const RangeSlider = memo<RangeSliderProps>(function RangeSlider({
   const pMin = getPercent(cMin);
   const pMax = getPercent(cMax);
 
+  // In RTL the visual order is reversed: max value appears on the left,
+  // min value on the right.  Flip percents so the push-apart algorithm
+  // always works in left-to-right visual space.
+  const tipPercents = isRtl ? [100 - pMax, 100 - pMin] : [pMin, pMax];
+  const tipLabels   = isRtl ? [fmt(cMax), fmt(cMin)]   : [fmt(cMin), fmt(cMax)];
+  const { slots: tipSlots, containerRef: tipContainerRef } = useTooltipLayout(tipPercents, tipLabels);
+
+  // Scale: number of major tick sections when no labels array is given
+  const scaleSections = labels
+    ? labels.length - 1
+    : Math.max(1, Math.min(20, Math.round((max - min) / step)));
+  const showRuler = ruler ?? (labels != null && labels.length > 0);
+
   const cssVars = {
     ...(trackColor ? { "--mrs-track-bg": trackColor } : {}),
     ...(rangeColor ? { "--mrs-range-bg": rangeColor } : {}),
@@ -133,19 +151,14 @@ const RangeSlider = memo<RangeSliderProps>(function RangeSlider({
       </span>
 
       {showTooltip && (
-        <div className="mrs-tooltips" aria-hidden="true">
-          <span
-            className="mrs-tooltip"
-            style={{ left: `calc(${pMin}% + ${thumbOffset(pMin)}px)` }}
-          >
-            {fmt(cMin)}
-          </span>
-          <span
-            className="mrs-tooltip"
-            style={{ left: `calc(${pMax}% + ${thumbOffset(pMax)}px)` }}
-          >
-            {fmt(cMax)}
-          </span>
+        <div ref={tipContainerRef} className="mrs-tooltips" aria-hidden="true">
+          {tipSlots.map((slot, i) =>
+            slot.visible ? (
+              <span key={i} className="mrs-tooltip" style={{ left: slot.left }}>
+                {slot.label}
+              </span>
+            ) : null
+          )}
         </div>
       )}
 
@@ -203,6 +216,15 @@ const RangeSlider = memo<RangeSliderProps>(function RangeSlider({
           <span className="mrs-label--left">{fmt(isRtl ? cMax : cMin)}</span>
           <span className="mrs-label--right">{fmt(isRtl ? cMin : cMax)}</span>
         </div>
+      )}
+
+      {(showRuler || (labels && labels.length > 0)) && (
+        <SliderScale
+          labels={labels}
+          ruler={showRuler}
+          subSteps={subSteps}
+          sections={scaleSections}
+        />
       )}
     </div>
   );

--- a/src/components/SingleSlider.tsx
+++ b/src/components/SingleSlider.tsx
@@ -3,6 +3,7 @@ import type { SingleSliderProps } from "../types";
 import { cx } from "../utils/cx";
 import { thumbOffset, toPercent } from "../utils/percent";
 import { useChangeListeners } from "../hooks/useChangeListeners";
+import SliderScale from "./SliderScale";
 import "../styles/index.css";
 
 const SingleSlider = memo<SingleSliderProps>(function SingleSlider({
@@ -29,6 +30,9 @@ const SingleSlider = memo<SingleSliderProps>(function SingleSlider({
   showTooltip = false,
   showLabels = true,
   formatLabel,
+  labels,
+  ruler,
+  subSteps,
   ariaLabel,
 }) {
   const fillRef = useRef<HTMLDivElement>(null);
@@ -71,6 +75,11 @@ const SingleSlider = memo<SingleSliderProps>(function SingleSlider({
     ...(labelColor ? { "--mrs-label-color": labelColor } : {}),
   } as React.CSSProperties;
 
+  const scaleSections = labels
+    ? labels.length - 1
+    : Math.max(1, Math.min(20, Math.round((max - min) / step)));
+  const showRuler = ruler ?? (labels != null && labels.length > 0);
+
   return (
     <div
       className={cx("mrs-slider", `mrs-theme-${theme}`, { "mrs-slider--disabled": disabled }, className)}
@@ -78,7 +87,7 @@ const SingleSlider = memo<SingleSliderProps>(function SingleSlider({
       aria-disabled={disabled}
     >
       {showTooltip && (
-        <div className="mrs-tooltips">
+        <div className="mrs-tooltips" aria-hidden="true">
           <span
             className="mrs-tooltip"
             style={{ left: `calc(${percent}% + ${thumbOffset(percent)}px)` }}
@@ -113,10 +122,19 @@ const SingleSlider = memo<SingleSliderProps>(function SingleSlider({
       />
 
       {showLabels && (
-        <div className="mrs-labels" style={labelStyle}>
+        <div className="mrs-labels" aria-hidden="true" style={labelStyle}>
           <span className="mrs-label--left">{fmt(min)}</span>
           <span className="mrs-label--right">{fmt(max)}</span>
         </div>
+      )}
+
+      {(showRuler || (labels && labels.length > 0)) && (
+        <SliderScale
+          labels={labels}
+          ruler={showRuler}
+          subSteps={subSteps}
+          sections={scaleSections}
+        />
       )}
     </div>
   );

--- a/src/components/SliderScale.tsx
+++ b/src/components/SliderScale.tsx
@@ -1,0 +1,113 @@
+import React, { memo } from "react";
+
+/** Resolve the boolean | number subSteps prop to a concrete count. */
+function resolveSubSteps(raw: boolean | number | undefined): number {
+  if (raw === true)  return 3;   // auto: 4 sub-divisions per section
+  if (!raw)          return 0;   // false | 0 | undefined
+  return Math.max(0, Math.floor(raw as number));
+}
+
+interface Tick {
+  pct: number;
+  major: boolean;
+}
+
+/** Generate major + optional minor ticks for `sections` equal intervals. */
+function buildTicks(sections: number, subSteps: number): Tick[] {
+  const ticks: Tick[] = [];
+  const segW = sections > 0 ? 100 / sections : 100;
+
+  for (let i = 0; i <= sections; i++) {
+    const pct = i * segW;
+    ticks.push({ pct, major: true });
+
+    if (subSteps > 0 && i < sections) {
+      for (let j = 1; j <= subSteps; j++) {
+        ticks.push({ pct: pct + (j / (subSteps + 1)) * segW, major: false });
+      }
+    }
+  }
+
+  return ticks;
+}
+
+export interface SliderScaleProps {
+  /** Custom evenly-spaced labels (day names, month names, etc.). */
+  labels?: string[];
+  /** Whether to render ruler tick marks. */
+  ruler: boolean;
+  /**
+   * Minor ticks between each pair of major ticks.
+   * Accepts the resolved boolean | number from the parent.
+   */
+  subSteps?: boolean | number;
+  /**
+   * Number of major sections when no `labels` are given.
+   * Typically `Math.min(20, Math.round((max - min) / step))`.
+   */
+  sections: number;
+}
+
+/**
+ * Renders an optional ruler (tick marks) and an optional row of evenly-spaced
+ * scale labels below a horizontal slider track.
+ *
+ * Used internally by RangeSlider and SingleSlider.
+ */
+const SliderScale = memo(function SliderScale({
+  labels,
+  ruler,
+  subSteps,
+  sections,
+}: SliderScaleProps) {
+  const n       = labels ? labels.length : sections + 1;
+  const segs    = Math.max(1, n - 1);
+  const minorN  = resolveSubSteps(subSteps);
+  const ticks   = ruler ? buildTicks(segs, minorN) : [];
+  const hasScale = labels && labels.length > 0;
+
+  if (!ruler && !hasScale) return null;
+
+  return (
+    <>
+      {ruler && (
+        <div className="mrs-ruler" aria-hidden="true">
+          {ticks.map((t, i) => (
+            <span
+              key={i}
+              className={t.major ? "mrs-ruler__tick mrs-ruler__tick--major" : "mrs-ruler__tick"}
+              style={{ left: `${t.pct}%` }}
+            />
+          ))}
+        </div>
+      )}
+
+      {hasScale && (
+        <div className="mrs-scale" aria-hidden="true">
+          {labels!.map((lbl, i) => {
+            const total = labels!.length;
+            const pct   = total === 1 ? 50 : (i / (total - 1)) * 100;
+
+            // First label: flush-left; last label: flush-right; others: centered
+            let style: React.CSSProperties;
+            if (i === 0) {
+              style = { left: 0 };
+            } else if (i === total - 1) {
+              style = { right: 0 };
+            } else {
+              style = { left: `${pct}%`, transform: "translateX(-50%)" };
+            }
+
+            return (
+              <span key={i} className="mrs-scale__label" style={style}>
+                {lbl}
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+});
+
+export default SliderScale;

--- a/src/components/VerticalSlider.tsx
+++ b/src/components/VerticalSlider.tsx
@@ -126,7 +126,7 @@ const VerticalSlider = memo<VerticalSliderProps>(function VerticalSlider({
       />
 
       {showLabels && (
-        <div className="mrs-labels mrs-labels--vertical" style={labelStyle}>
+        <div className="mrs-labels mrs-labels--vertical" aria-hidden="true" style={labelStyle}>
           <span className="mrs-label--top">{fmt(max)}</span>
           <span className="mrs-label--bottom">{fmt(min)}</span>
         </div>

--- a/src/hooks/useTooltipLayout.ts
+++ b/src/hooks/useTooltipLayout.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { computeTooltipLayout } from "../utils/tooltipLayout";
+import { thumbOffset } from "../utils/percent";
+
+const THUMB_W = 18;
+
+export interface TooltipSlot {
+  left: string;
+  label: string;
+  visible: boolean;
+}
+
+/**
+ * Compute collision-free `left` positions for a row of tooltips.
+ *
+ * Attach `containerRef` to the `.mrs-tooltips` wrapper div.
+ * `percents` must be in visual left-to-right order — callers should flip
+ * values to `100 - pct` and reorder labels when `direction="rtl"`.
+ *
+ * On the first render the hook falls back to the standard `calc(p% + offset)`
+ * formula (no measurement available yet).  Once the container width is known
+ * the push-apart + merge algorithm takes over and all subsequent renders
+ * (including rapid drag updates) use pixel positions.
+ */
+export function useTooltipLayout(
+  percents: number[],
+  labels: string[],
+  thumbW = THUMB_W,
+): {
+  slots: TooltipSlot[];
+  containerRef: RefObject<HTMLDivElement>;
+} {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerW, setContainerW] = useState(0);
+
+  // Sync container width after every render.
+  // React bails out of a re-render when the value is identical, so this is
+  // a cheap idempotent read on each drag frame.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el) setContainerW(el.offsetWidth);
+  });
+
+  // Keep width in sync when the slider is resized (e.g. responsive layouts).
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(([entry]) => {
+      setContainerW(Math.round(entry.contentRect.width));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const raw = percents.map((p, i) => ({ percent: p, label: labels[i] }));
+
+  const slots: TooltipSlot[] =
+    containerW > 0
+      ? computeTooltipLayout(raw, containerW, thumbW).map(r => ({
+          left: `${r.centerPx}px`,
+          label: r.label,
+          visible: r.visible,
+        }))
+      : raw.map((it, i) => ({
+          left: `calc(${it.percent}% + ${thumbOffset(it.percent, thumbW)}px)`,
+          label: labels[i],
+          visible: true,
+        }));
+
+  return { slots, containerRef };
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -206,6 +206,8 @@
   position: relative;
   height: 26px;
   pointer-events: none;
+  /* Allow push-apart tooltips to escape the container bounds */
+  overflow: visible;
 }
 
 .mrs-tooltip {
@@ -221,6 +223,10 @@
   white-space:  nowrap;
   transition:   left var(--mrs-transition);
   pointer-events: none;
+  /* Prevent layout shifts from overflowing the page horizontally */
+  max-width: calc(100vw - 16px);
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .mrs-tooltip::after {
@@ -230,6 +236,50 @@
   transform: translateX(-50%);
   border: 4px solid transparent;
   border-top-color: var(--mrs-tooltip-bg);
+}
+
+/* ── Ruler (tick marks) ─────────────────────────────────────── */
+.mrs-ruler {
+  position: relative;
+  height: 8px;
+  margin-top: 3px;
+  pointer-events: none;
+  overflow: visible;
+}
+
+/* Minor tick (default — short) */
+.mrs-ruler__tick {
+  position: absolute;
+  width: 1px;
+  height: 4px;
+  bottom: 0;
+  background: var(--mrs-label-color);
+  opacity: 0.3;
+  transform: translateX(-50%);
+}
+
+/* Major tick — taller and more opaque */
+.mrs-ruler__tick--major {
+  height: 8px;
+  opacity: 0.55;
+}
+
+/* ── Scale labels (custom labels array) ─────────────────────── */
+.mrs-scale {
+  position: relative;
+  height: 18px;
+  margin-top: 2px;
+  pointer-events: none;
+  font-size: 11px;
+  color: var(--mrs-label-color);
+  overflow: visible;
+}
+
+.mrs-scale__label {
+  position: absolute;
+  top: 0;
+  white-space: nowrap;
+  line-height: 1;
 }
 
 /* ============================================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,20 @@ export interface BaseSliderProps {
   showTooltip?: boolean;
   showLabels?: boolean;
   formatLabel?: (value: number) => string;
+  // scale / ruler
+  /** Evenly-spaced text labels rendered below the slider (e.g. day names, month names). */
+  labels?: string[];
+  /**
+   * Show ruler tick marks below the track.
+   * Defaults to `true` when a `labels` array is provided, `false` otherwise.
+   */
+  ruler?: boolean;
+  /**
+   * Number of minor tick marks to insert between each pair of major ticks.
+   * Pass `true` to use the default of 3 minor ticks (4 sub-divisions per section).
+   * Pass `false` or `0` to show major ticks only.
+   */
+  subSteps?: boolean | number;
 }
 
 // ─── Single ────────────────────────────────────────────────────────────────

--- a/src/utils/tooltipLayout.ts
+++ b/src/utils/tooltipLayout.ts
@@ -1,0 +1,106 @@
+/**
+ * Tooltip collision-resolution utilities.
+ *
+ * The push-apart algorithm converts percent positions to pixel centers,
+ * iteratively moves adjacent tooltips apart until they no longer overlap,
+ * clamps positions to the container bounds, then merges any pair of
+ * adjacent tooltips that display the same formatted value.
+ */
+
+/** Approx character width (px) at font-size 11px / weight 600. */
+const CHAR_W  = 7;
+/** Horizontal padding inside a tooltip (left + right). */
+const H_PAD   = 14;
+/** Minimum tooltip width even for very short labels. */
+const MIN_W   = 28;
+/** Minimum pixel gap between adjacent tooltip edges. */
+const TIP_GAP = 6;
+/** Default thumb/dial diameter used for edge-correction math. */
+const THUMB_W = 18;
+
+/** Rough rendered-width estimate for a tooltip based on its label string. */
+function estimateWidth(label: string): number {
+  return Math.max(label.length * CHAR_W + H_PAD, MIN_W);
+}
+
+/**
+ * Convert a percent value [0, 100] to the pixel center of the tooltip above
+ * the corresponding thumb, measured from the container's left edge.
+ *
+ * A native range thumb travels from thumbW/2 px (at 0 %) to
+ * containerW - thumbW/2 px (at 100 %) because the browser prevents the
+ * thumb from going past the track edges.
+ */
+function pctToCenter(pct: number, cw: number, thumbW: number): number {
+  return (pct / 100) * (cw - thumbW) + thumbW / 2;
+}
+
+export interface ResolvedTooltip {
+  /** Pixel position of the tooltip center, relative to the container's left edge. */
+  centerPx: number;
+  /** Formatted label string to display. */
+  label: string;
+  /** False when this tooltip has been merged into an adjacent one. */
+  visible: boolean;
+}
+
+/**
+ * Compute collision-free tooltip positions for a set of thumbs.
+ *
+ * @param items      Tooltip descriptors in left-to-right visual order (sorted by percent).
+ * @param containerW Pixel width of the slider container.
+ * @param thumbW     Thumb diameter in pixels (default 18).
+ * @param gap        Minimum pixel gap between adjacent tooltip edges (default 6).
+ */
+export function computeTooltipLayout(
+  items: ReadonlyArray<{ percent: number; label: string }>,
+  containerW: number,
+  thumbW = THUMB_W,
+  gap = TIP_GAP,
+): ResolvedTooltip[] {
+  const n = items.length;
+  if (n === 0) return [];
+  if (containerW <= 0) {
+    return Array.from(items, it => ({ centerPx: 0, label: it.label, visible: true }));
+  }
+
+  const centers = Array.from(items, it => pctToCenter(it.percent, containerW, thumbW));
+  const widths  = Array.from(items, it => estimateWidth(it.label));
+
+  // Forward pass: push each tooltip right past the previous one.
+  for (let i = 1; i < n; i++) {
+    const minPos = centers[i - 1] + widths[i - 1] / 2 + gap + widths[i] / 2;
+    if (centers[i] < minPos) centers[i] = minPos;
+  }
+
+  // Backward pass: pull each tooltip left past the next one.
+  for (let i = n - 2; i >= 0; i--) {
+    const maxPos = centers[i + 1] - widths[i + 1] / 2 - gap - widths[i] / 2;
+    if (centers[i] > maxPos) centers[i] = maxPos;
+  }
+
+  // Clamp first and last tooltips to the container bounds.
+  centers[0]     = Math.max(centers[0],     widths[0] / 2);
+  centers[n - 1] = Math.min(centers[n - 1], containerW - widths[n - 1] / 2);
+
+  const result: ResolvedTooltip[] = Array.from(items, (it, i) => ({
+    centerPx: centers[i],
+    label: it.label,
+    visible: true,
+  }));
+
+  // Merge adjacent tooltips that display the same formatted value.
+  // The surviving tooltip is centered between the two original positions.
+  for (let i = 0; i < n - 1; i++) {
+    if (result[i].visible && items[i].label === items[i + 1].label) {
+      result[i] = {
+        centerPx: (centers[i] + centers[i + 1]) / 2,
+        label: items[i].label,
+        visible: true,
+      };
+      result[i + 1] = { ...result[i + 1], visible: false };
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Tooltip overlap fix
- Add src/utils/tooltipLayout.ts: push-apart + merge algorithm that converts percent positions to pixel centers, resolves overlaps via forward/backward passes, clamps to container bounds, and merges adjacent tooltips that display the same formatted value
- Add src/hooks/useTooltipLayout.ts: React hook wrapping the algorithm; measures container width via useEffect + ResizeObserver and feeds pixel-based left positions to tooltip spans
- Wire useTooltipLayout into RangeSlider and MultiPointSlider; remove direct thumbOffset usage from those components
- Fix RTL tooltip positioning in RangeSlider (percents were mapped to value-space; now reflected to visual left-to-right space)
- Add aria-hidden="true" to .mrs-tooltips and .mrs-labels in SingleSlider (was missing — screen readers double-announced values)
- Add aria-hidden="true" to .mrs-labels--vertical in VerticalSlider
- Add overflow:visible + max-width guard to .mrs-tooltip CSS

Scale slider (ruler + labels + subSteps)
- Add src/components/SliderScale.tsx: shared internal component that renders a ruler (major + minor tick marks) and an evenly-spaced row of custom text labels below the slider track
- Add labels, ruler, subSteps props to BaseSliderProps, RangeSlider, and SingleSlider; ruler defaults to true when labels array is set
- subSteps accepts boolean (true = 3 minor ticks) or an explicit number
- Auto tick count: Math.min(20, round((max-min)/step)) when no labels
- Add 6 annotated examples to example/src/App.js covering: simple range with ruler, week-day labels, date-range months, time-range with subSteps minor ticks, negative/positive range, step-snapping
- Add 6 pixel-accurate SVG demo images to docs/images/
- Update README with Scale Slider section: prop table, 6 code examples, and inline SVG previews for each variant