### PR TITLE
fix(tooltipLayout): resolve overlap when thumbs are near a container …

### DIFF
--- a/src/utils/tooltipLayout.ts
+++ b/src/utils/tooltipLayout.ts
@@ -2,9 +2,8 @@
  * Tooltip collision-resolution utilities.
  *
  * The push-apart algorithm converts percent positions to pixel centers,
- * iteratively moves adjacent tooltips apart until they no longer overlap,
- * clamps positions to the container bounds, then merges any pair of
- * adjacent tooltips that display the same formatted value.
+ * resolves overlaps, clamps to container bounds (while keeping gap
+ * constraints intact), then merges adjacent tooltips with the same label.
  */
 
 /** Approx character width (px) at font-size 11px / weight 600. */
@@ -47,7 +46,20 @@ export interface ResolvedTooltip {
 /**
  * Compute collision-free tooltip positions for a set of thumbs.
  *
- * @param items      Tooltip descriptors in left-to-right visual order (sorted by percent).
+ * Algorithm (7 steps, resolves all edge cases):
+ *   1. Forward pass  — push each tooltip right past the previous one
+ *   2. Backward pass — pull each tooltip left past the next one
+ *   3. Clamp RIGHT edge
+ *   4. Backward pass — pull preceding tooltips left after right-clamp
+ *   5. Clamp LEFT edge
+ *   6. Forward pass  — push following tooltips right after left-clamp
+ *   7. Final RIGHT clamp cleanup
+ *
+ * Why 7 steps: clamping one edge invalidates the gap constraint set by
+ * the previous pass, so each clamp must be followed by a corrective pass
+ * in the opposite direction.
+ *
+ * @param items      Tooltip descriptors in left-to-right visual order.
  * @param containerW Pixel width of the slider container.
  * @param thumbW     Thumb diameter in pixels (default 18).
  * @param gap        Minimum pixel gap between adjacent tooltip edges (default 6).
@@ -67,35 +79,76 @@ export function computeTooltipLayout(
   const centers = Array.from(items, it => pctToCenter(it.percent, containerW, thumbW));
   const widths  = Array.from(items, it => estimateWidth(it.label));
 
-  // Forward pass: push each tooltip right past the previous one.
+  /** Minimum center-to-center distance between tooltip i and j. */
+  const minDist = (i: number, j: number) => widths[i] / 2 + gap + widths[j] / 2;
+
+  // ── Step 1: Forward pass ──────────────────────────────────────────────────
+  // Push each tooltip right to clear the one before it.
   for (let i = 1; i < n; i++) {
-    const minPos = centers[i - 1] + widths[i - 1] / 2 + gap + widths[i] / 2;
-    if (centers[i] < minPos) centers[i] = minPos;
+    const need = centers[i - 1] + minDist(i - 1, i);
+    if (centers[i] < need) centers[i] = need;
   }
 
-  // Backward pass: pull each tooltip left past the next one.
+  // ── Step 2: Backward pass ─────────────────────────────────────────────────
+  // Pull each tooltip left to clear the one after it.
   for (let i = n - 2; i >= 0; i--) {
-    const maxPos = centers[i + 1] - widths[i + 1] / 2 - gap - widths[i] / 2;
-    if (centers[i] > maxPos) centers[i] = maxPos;
+    const maxP = centers[i + 1] - minDist(i, i + 1);
+    if (centers[i] > maxP) centers[i] = maxP;
   }
 
-  // Clamp first and last tooltips to the container bounds.
-  centers[0]     = Math.max(centers[0],     widths[0] / 2);
+  // ── Step 3: Clamp RIGHT edge ──────────────────────────────────────────────
+  // The last tooltip must not overflow the right side of the container.
   centers[n - 1] = Math.min(centers[n - 1], containerW - widths[n - 1] / 2);
 
+  // ── Step 4: Backward pass after right-clamp ───────────────────────────────
+  // The right-clamp may have pushed center[n-1] LEFT, breaking the gap
+  // constraint with center[n-2].  Pull all preceding tooltips left.
+  for (let i = n - 2; i >= 0; i--) {
+    const maxP = centers[i + 1] - minDist(i, i + 1);
+    if (centers[i] > maxP) centers[i] = maxP;
+  }
+
+  // ── Step 5: Clamp LEFT edge ───────────────────────────────────────────────
+  // The first tooltip must not overflow the left side of the container.
+  centers[0] = Math.max(centers[0], widths[0] / 2);
+
+  // ── Step 6: Forward pass after left-clamp ────────────────────────────────
+  // The left-clamp may have pushed center[0] RIGHT, breaking the gap
+  // constraint with center[1].  Push all following tooltips right.
+  for (let i = 1; i < n; i++) {
+    const need = centers[i - 1] + minDist(i - 1, i);
+    if (centers[i] < need) centers[i] = need;
+  }
+
+  // ── Step 7: Final right-clamp cleanup ─────────────────────────────────────
+  // In extremely narrow containers the last tooltip may have been pushed
+  // outside the right edge by step 6.  Re-clamp it one last time.
+  centers[n - 1] = Math.min(centers[n - 1], containerW - widths[n - 1] / 2);
+
+  // ── Build result & merge ──────────────────────────────────────────────────
   const result: ResolvedTooltip[] = Array.from(items, (it, i) => ({
     centerPx: centers[i],
     label: it.label,
     visible: true,
   }));
 
-  // Merge adjacent tooltips that display the same formatted value.
-  // The surviving tooltip is centered between the two original positions.
   for (let i = 0; i < n - 1; i++) {
-    if (result[i].visible && items[i].label === items[i + 1].label) {
+    if (!result[i].visible) continue;
+
+    const sameLabel = items[i].label === items[i + 1].label;
+    // Remaining gap between these two after all passes (negative = still overlapping).
+    const remainingGap = centers[i + 1] - centers[i] - widths[i] / 2 - widths[i + 1] / 2;
+    // Merge when values are identical OR when the container is too narrow to
+    // separate them (safety net for extreme cases).
+    const shouldMerge = sameLabel || remainingGap < 0;
+
+    if (shouldMerge) {
+      const mergedLabel = sameLabel
+        ? items[i].label
+        : `${items[i].label} – ${items[i + 1].label}`;
       result[i] = {
         centerPx: (centers[i] + centers[i + 1]) / 2,
-        label: items[i].label,
+        label: mergedLabel,
         visible: true,
       };
       result[i + 1] = { ...result[i + 1], visible: false };


### PR DESCRIPTION
…edge

Root cause: the original algorithm ran forward → backward → clamp(both edges).  Clamping the right edge moved center[n-1] leftward, which invalidated the gap constraint just established by the backward pass. center[n-2] was not updated, so the two tooltips remained overlapping.

The same defect mirrored on the left edge (clamp pushes center[0] rightward, forward pass for center[1] was not re-run).

Fix — 7-step algorithm that corrects for each clamp with a compensating pass in the opposite direction:
  1. Forward pass  (push each tooltip right past the previous)
  2. Backward pass (pull each tooltip left past the next)
  3. Clamp RIGHT edge
  4. Backward pass after right-clamp (pull preceding tooltips left)
  5. Clamp LEFT edge
  6. Forward pass after left-clamp (push following tooltips right)
  7. Final right-clamp cleanup

Additionally, the merge step now has a safety-net branch: if two adjacent tooltips still overlap after all 7 steps (only possible in extremely narrow containers), they are merged into a single "val1 – val2" label instead of being rendered on top of each other.

Verified against:
  - 86 % + 100 % in 280 px container (the reported time-range bug) → gap=55 px OK
  - 0 % + 3 % in 280 px container (left-edge mirror case) → gap=34 px OK
  - 88 % + 95 % + 100 % in 400 px container (3-way cluster) → gaps=34,38 px OK
  - 25 % + 75 % in 600 px container (normal spread) → no regression
  - Extremely narrow container → merged into single tooltip