### PR TITLE
fix(tooltip): resolve thumb/tooltip overlap when showTooltip is enabled

### DIFF
--- a/example/src/App.css
+++ b/example/src/App.css
@@ -14,58 +14,123 @@ body {
 
 a { color: inherit; }
 
-/* ── Page shell ──────────────────────────────────────────────── */
+/* ── Top navbar ──────────────────────────────────────────────── */
 
-.page-shell { min-height: 100vh; }
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  height: 56px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+  padding: 0 clamp(16px, 4vw, 48px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.top-nav__brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  font-size: 15px;
+  color: #0f172a;
+  white-space: nowrap;
+}
+
+.top-nav__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2563eb;
+  flex-shrink: 0;
+}
+
+.top-nav__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.top-nav__install {
+  font-size: 12px;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  padding: 4px 10px;
+  border-radius: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 320px;
+  color: #0f172a;
+}
+
+.top-nav__npm {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  background: #cc3534;
+  color: #fff;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+  letter-spacing: 0.03em;
+  transition: opacity 0.12s;
+}
+
+.top-nav__npm:hover { opacity: 0.85; }
 
 /* ── Hero ────────────────────────────────────────────────────── */
 
 .hero-section {
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
   gap: 32px;
   align-items: center;
-  min-height: 78vh;
-  padding: 56px clamp(20px, 5vw, 72px) 40px;
+  padding: 52px clamp(16px, 4vw, 48px) 40px;
   background:
-    linear-gradient(135deg, rgba(37,99,235,0.12), transparent 38%),
-    linear-gradient(315deg, rgba(15,118,110,0.13), transparent 34%),
+    linear-gradient(135deg, rgba(37,99,235,0.1) 0%, transparent 40%),
+    linear-gradient(315deg, rgba(15,118,110,0.1) 0%, transparent 40%),
     #eef4fb;
   border-bottom: 1px solid #dbe4ea;
 }
 
-.hero-content { max-width: 680px; }
+.hero-content { max-width: 600px; }
 
-.eyebrow,
-.demo-kicker {
+.eyebrow {
   display: inline-flex;
   align-items: center;
   color: #2563eb;
   font-size: 12px;
   font-weight: 800;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
+  margin: 0 0 8px;
 }
 
 .hero-section h1 {
-  margin: 10px 0 16px;
-  font-size: clamp(36px, 6vw, 68px);
-  line-height: 0.97;
-  letter-spacing: -0.01em;
+  margin: 0 0 14px;
+  font-size: clamp(28px, 5vw, 52px);
+  line-height: 1;
+  letter-spacing: -0.02em;
 }
 
 .hero-text {
-  margin: 0;
+  margin: 0 0 20px;
   color: #334155;
-  font-size: 18px;
-  line-height: 1.6;
+  font-size: 16px;
+  line-height: 1.65;
 }
 
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 28px;
+  gap: 10px;
+  margin-bottom: 18px;
 }
 
 .primary-link,
@@ -73,7 +138,7 @@ a { color: inherit; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 44px;
+  min-height: 40px;
   padding: 0 18px;
   border-radius: 6px;
   font-weight: 700;
@@ -87,39 +152,17 @@ a { color: inherit; }
 .primary-link   { background: #2563eb; color: #fff; }
 .secondary-link { border: 1px solid #cbd5e1; background: #fff; color: #0f172a; }
 
-.hero-demo {
-  border: 1px solid #dbe4ea;
-  border-radius: 12px;
-  background: #fff;
-  box-shadow: 0 20px 48px rgba(15,23,42,0.08);
-  padding: 28px;
-}
-
-.hero-value {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  margin-top: 28px;
-  padding-top: 16px;
-  border-top: 1px solid #e2e8f0;
-}
-
-.hero-value span { color: #475569; font-size: 14px; }
-.hero-value strong { color: #0f172a; font-size: 18px; font-weight: 700; }
-
 .hero-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 16px;
+  gap: 6px;
 }
 
 .chip {
   display: inline-flex;
   align-items: center;
-  height: 24px;
-  padding: 0 10px;
+  height: 22px;
+  padding: 0 8px;
   border-radius: 99px;
   background: #eff6ff;
   color: #2563eb;
@@ -129,144 +172,265 @@ a { color: inherit; }
   text-transform: uppercase;
 }
 
-/* ── Quick start ─────────────────────────────────────────────── */
-
-.quick-start {
-  display: grid;
-  grid-template-columns: minmax(220px, 0.55fr) minmax(0, 1.45fr);
-  gap: 24px;
-  margin: 32px clamp(20px, 5vw, 72px);
-  padding: 24px;
+.hero-demo {
   border: 1px solid #dbe4ea;
-  border-radius: 10px;
+  border-radius: 12px;
   background: #fff;
-  box-shadow: 0 4px 16px rgba(15,23,42,0.05);
+  box-shadow: 0 16px 40px rgba(15,23,42,0.08);
+  padding: 24px;
 }
 
-.quick-start h2 { margin: 6px 0 0; font-size: 24px; }
+.hero-demo__label {
+  margin: 0 0 16px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.hero-value {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 20px;
+  padding-top: 14px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.hero-value span  { color: #475569; font-size: 13px; }
+.hero-value strong { color: #0f172a; font-size: 17px; font-weight: 700; }
+
+/* ── Docs layout ─────────────────────────────────────────────── */
+
+.docs-layout {
+  display: flex;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+.docs-main {
+  flex: 1;
+  min-width: 0;
+  padding: 0 clamp(16px, 3vw, 48px) 80px;
+}
+
+/* ── Right sidebar ───────────────────────────────────────────── */
+
+.docs-sidebar {
+  width: 228px;
+  min-width: 228px;
+  flex-shrink: 0;
+  position: sticky;
+  top: 56px;
+  height: calc(100vh - 56px);
+  overflow-y: auto;
+  border-left: 1px solid #e2e8f0;
+  padding: 24px 0 40px;
+  background: #fff;
+  scrollbar-width: thin;
+  scrollbar-color: #cbd5e1 transparent;
+}
+
+.docs-sidebar::-webkit-scrollbar       { width: 4px; }
+.docs-sidebar::-webkit-scrollbar-track { background: transparent; }
+.docs-sidebar::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 4px; }
+
+.sidebar-heading {
+  padding: 0 20px 10px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #94a3b8;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-bottom: 1px solid #f1f5f9;
+  margin-bottom: 8px;
+}
+
+.sidebar-group {
+  margin-bottom: 2px;
+}
+
+.sidebar-section-btn {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 6px 20px;
+  border: none;
+  background: none;
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+  cursor: pointer;
+  transition: color 0.1s;
+  border-left: 2px solid transparent;
+}
+
+.sidebar-section-btn:hover { color: #2563eb; }
+
+.sidebar-section-btn--active {
+  color: #2563eb;
+  border-left-color: #2563eb;
+  background: #eff6ff;
+}
+
+.sidebar-item-btn {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 4px 20px 4px 32px;
+  border: none;
+  background: none;
+  font-size: 12px;
+  color: #6b7280;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+  border-left: 2px solid transparent;
+}
+
+.sidebar-item-btn:hover { background: #f3f4f6; color: #374151; }
+
+.sidebar-item-btn--active {
+  background: #eff6ff;
+  color: #2563eb;
+  font-weight: 600;
+  border-left-color: #93c5fd;
+}
 
 /* ── Section header ──────────────────────────────────────────── */
 
+.quick-start,
+.examples-layout {
+  padding: 32px 0 20px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.quick-start:first-of-type { padding-top: 28px; }
+.examples-layout:last-of-type { border-bottom: none; }
+
+.demo-kicker {
+  display: inline-flex;
+  align-items: center;
+  color: #2563eb;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
 .section-header {
-  padding: 8px 0 4px;
-  border-bottom: 2px solid #e2e8f0;
-  margin-bottom: 4px;
+  padding-bottom: 20px;
 }
 
 .section-header h2 {
-  margin: 6px 0 0;
-  font-size: 28px;
+  margin: 4px 0 0;
+  font-size: 24px;
+  font-weight: 800;
   letter-spacing: -0.01em;
 }
 
 .section-desc {
-  margin: 8px 0 0;
-  color: #475569;
-  font-size: 15px;
-}
-
-/* ── Examples layout ─────────────────────────────────────────── */
-
-.examples-layout {
-  display: grid;
-  gap: 16px;
-  padding: 28px clamp(20px, 5vw, 72px) 8px;
-}
-
-/* ── Demo section (default: 3-col) ───────────────────────────── */
-
-.demo-section {
-  display: grid;
-  grid-template-columns: minmax(200px, 0.65fr) minmax(260px, 0.9fr) minmax(300px, 1.15fr);
-  gap: 24px;
-  align-items: center;
-  padding: 24px;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  background: #fff;
-  box-shadow: 0 2px 8px rgba(15,23,42,0.04);
-}
-
-.demo-copy h3 {
-  margin: 0 0 6px;
-  font-size: 17px;
-  font-weight: 700;
-}
-
-.demo-copy p {
-  margin: 0;
+  margin: 6px 0 0;
   color: #475569;
   font-size: 14px;
   line-height: 1.55;
 }
 
-.demo-meta { margin-top: 14px; }
-.demo-meta strong { font-size: 16px; color: #0f172a; }
+/* ── Demo section (2-col) ────────────────────────────────────── */
 
-.demo-panel { min-width: 0; padding: 8px 0 16px; }
+.demo-section {
+  display: grid;
+  grid-template-columns: 1fr 1.05fr;
+  gap: 20px;
+  padding: 20px 0;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.demo-section:last-child { border-bottom: none; }
+
+/* Compact: demo takes less space (vertical, circular demos) */
+.demo-section--compact {
+  grid-template-columns: auto 1fr;
+}
+
+.demo-left {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.demo-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.demo-desc {
+  margin: 0;
+  color: #475569;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.demo-meta { }
+.demo-meta strong { font-size: 14px; font-weight: 700; color: #0f172a; }
+
+.demo-panel { padding-top: 8px; }
 
 /* ── Code block ──────────────────────────────────────────────── */
 
 .code-block {
   margin: 0;
+  height: 100%;
   overflow-x: auto;
   border: 1px solid #1e293b;
   border-radius: 8px;
   background: #0f172a;
   color: #e2e8f0;
-  font-size: 12.5px;
+  font-size: 12px;
   line-height: 1.6;
+  align-self: start;
 }
 
 .code-block code {
   display: block;
-  padding: 16px 18px;
+  padding: 14px 16px;
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
   white-space: pre;
 }
 
-/* ── Vertical slider demo ────────────────────────────────────── */
-
-.demo-section--vertical {
-  grid-template-columns: minmax(200px, 0.65fr) auto minmax(300px, 1.15fr);
-}
-
-.demo-panel--vertical { padding: 16px 0; }
+/* ── Equalizer (vertical sliders) ───────────────────────────── */
 
 .eq-row {
   display: flex;
   align-items: flex-end;
-  gap: 28px;
-  padding: 12px 8px;
+  gap: 24px;
+  padding: 8px 0;
 }
 
 .eq-channel {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
 .eq-label {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   color: #64748b;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
-/* ── Circular slider demo ────────────────────────────────────── */
-
-.demo-section--circular {
-  grid-template-columns: minmax(200px, 0.55fr) auto minmax(300px, 1.15fr);
-}
-
-.demo-panel--circular { padding: 12px 0; }
+/* ── Circular grid ───────────────────────────────────────────── */
 
 .circular-grid {
   display: grid;
   grid-template-columns: repeat(4, auto);
-  gap: 20px;
+  gap: 16px;
   justify-content: start;
 }
 
@@ -274,37 +438,30 @@ a { color: inherit; }
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
 .circular-label {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   color: #64748b;
   letter-spacing: 0.03em;
   text-transform: uppercase;
 }
 
-/* ── Themes demo ─────────────────────────────────────────────── */
-
-.demo-section--themes {
-  grid-template-columns: minmax(200px, 0.55fr) auto minmax(300px, 1.15fr);
-  align-items: start;
-}
-
-.demo-panel--themes { padding: 12px 0; }
+/* ── Theme cards ─────────────────────────────────────────────── */
 
 .theme-row {
   display: grid;
-  grid-template-columns: repeat(2, 200px);
-  gap: 16px;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
 }
 
 .theme-card {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 16px;
+  padding: 14px;
   border-radius: 10px;
   border: 1px solid #e2e8f0;
 }
@@ -332,34 +489,25 @@ a { color: inherit; }
 
 .theme-card--dark .theme-card__value { color: #475569; }
 
-/* ── Legacy compatibility (old .container / .slider classes) ─── */
-
-.container { height: auto; display: block; }
-.container strong { display: inline-block; margin-bottom: 18px; }
-.container > div { min-height: 54px; }
-.slider { max-width: 100%; }
-.thumb  { max-width: 100%; }
-
 /* ── Responsive ──────────────────────────────────────────────── */
 
-@media (max-width: 1100px) {
-  .hero-section              { grid-template-columns: 1fr; min-height: auto; }
-  .quick-start               { grid-template-columns: 1fr; }
-  .demo-section              { grid-template-columns: 1fr; }
-  .demo-section--vertical    { grid-template-columns: 1fr; }
-  .demo-section--circular    { grid-template-columns: 1fr; }
-  .demo-section--themes      { grid-template-columns: 1fr; }
-  .circular-grid             { grid-template-columns: repeat(2, auto); }
-  .theme-row                 { grid-template-columns: 1fr 1fr; }
+@media (max-width: 1200px) {
+  .docs-sidebar { display: none; }
 }
 
-@media (max-width: 640px) {
-  .hero-section    { padding-top: 32px; }
-  .hero-section h1 { font-size: 38px; }
-  .hero-text       { font-size: 16px; }
-  .hero-demo,
-  .demo-section    { padding: 18px; }
-  .circular-grid   { grid-template-columns: repeat(2, auto); }
-  .theme-row       { grid-template-columns: 1fr; }
-  .eq-row          { gap: 16px; }
+@media (max-width: 900px) {
+  .hero-section { grid-template-columns: 1fr; }
+  .demo-section { grid-template-columns: 1fr; }
+  .demo-section--compact { grid-template-columns: 1fr; }
+  .circular-grid { grid-template-columns: repeat(2, auto); }
+  .theme-row     { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 560px) {
+  .hero-section h1 { font-size: 28px; }
+  .hero-text       { font-size: 15px; }
+  .top-nav__install { display: none; }
+  .circular-grid { grid-template-columns: repeat(2, auto); }
+  .theme-row     { grid-template-columns: 1fr; }
+  .eq-row        { gap: 14px; }
 }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,6 +1,6 @@
 /** @format */
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   RangeSlider,
   SingleSlider,
@@ -10,8 +10,76 @@ import {
 } from "react-js-multi-range-sliders";
 import "./App.css";
 
-/* ─── Helpers ────────────────────────────────────────────────── */
+/* ─── Sidebar navigation structure ──────────────────────────── */
+const NAV = [
+  {
+    id: "install",
+    label: "Quick Start",
+    items: [{ id: "install", label: "Installation" }],
+  },
+  {
+    id: "range-slider",
+    label: "RangeSlider",
+    items: [
+      { id: "controlled",  label: "Controlled value" },
+      { id: "budget",      label: "Default value + step" },
+      { id: "booking",     label: "Minimum distance" },
+      { id: "overlap",     label: "Allow overlap" },
+      { id: "rtl",         label: "RTL direction" },
+      { id: "disabled",    label: "Disabled" },
+      { id: "callbacks",   label: "Callbacks" },
+    ],
+  },
+  {
+    id: "single-slider",
+    label: "SingleSlider",
+    items: [
+      { id: "volume",  label: "Basic" },
+      { id: "opacity", label: "With tooltip" },
+      { id: "price",   label: "Custom label + step" },
+    ],
+  },
+  {
+    id: "vertical-slider",
+    label: "VerticalSlider",
+    items: [
+      { id: "equalizer",       label: "Equalizer" },
+      { id: "vertical-themes", label: "Themes" },
+    ],
+  },
+  {
+    id: "multi-point",
+    label: "MultiPointSlider",
+    items: [
+      { id: "price-range",          label: "Four-stop filter" },
+      { id: "multipoint-material",  label: "Material theme" },
+    ],
+  },
+  {
+    id: "circular-slider",
+    label: "CircularSlider",
+    items: [{ id: "circular-demos", label: "All four themes" }],
+  },
+  {
+    id: "scale-slider",
+    label: "Scale Slider",
+    items: [
+      { id: "scale-simple",    label: "Simple range" },
+      { id: "scale-weekdays",  label: "Week days" },
+      { id: "scale-daterange", label: "Date range" },
+      { id: "scale-time",      label: "Time-Range" },
+      { id: "scale-negative",  label: "Negative/positive" },
+      { id: "scale-steponly",  label: "Step snapping" },
+    ],
+  },
+  {
+    id: "themes",
+    label: "Themes",
+    items: [{ id: "theme-grid", label: "Four built-in themes" }],
+  },
+];
 
+/* ─── Helpers ────────────────────────────────────────────────── */
 function CodeBlock({ children }) {
   return (
     <pre className="code-block">
@@ -20,15 +88,15 @@ function CodeBlock({ children }) {
   );
 }
 
-function DemoSection({ id, title, description, code, meta, children, layout }) {
+function DemoSection({ id, title, description, code, meta, children, extraClass }) {
   return (
-    <section className={`demo-section${layout ? ` demo-section--${layout}` : ""}`} id={id}>
-      <div className="demo-copy">
-        <h3>{title}</h3>
-        <p>{description}</p>
+    <section className={`demo-section${extraClass ? ` ${extraClass}` : ""}`} id={id}>
+      <div className="demo-left">
+        <h3 className="demo-title">{title}</h3>
+        <p className="demo-desc">{description}</p>
         {meta != null && <div className="demo-meta">{meta}</div>}
+        <div className="demo-panel">{children}</div>
       </div>
-      <div className="demo-panel">{children}</div>
       <CodeBlock>{code}</CodeBlock>
     </section>
   );
@@ -44,43 +112,79 @@ function SectionHeader({ tag, title, description }) {
   );
 }
 
-/* ─── App ────────────────────────────────────────────────────── */
+/* ─── Right sidebar ──────────────────────────────────────────── */
+function Sidebar({ activeId }) {
+  const scrollTo = (id) => {
+    const el = document.getElementById(id);
+    if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
+  return (
+    <aside className="docs-sidebar">
+      <p className="sidebar-heading">On this page</p>
+      {NAV.map((section) => (
+        <div className="sidebar-group" key={section.id}>
+          <button
+            className={`sidebar-section-btn${
+              activeId === section.id ? " sidebar-section-btn--active" : ""
+            }`}
+            onClick={() => scrollTo(section.id)}
+          >
+            {section.label}
+          </button>
+          {section.items.map((item) => (
+            <button
+              key={item.id}
+              className={`sidebar-item-btn${
+                activeId === item.id ? " sidebar-item-btn--active" : ""
+              }`}
+              onClick={() => scrollTo(item.id)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      ))}
+    </aside>
+  );
+}
+
+/* ─── App ────────────────────────────────────────────────────── */
 export default function App() {
   /* RangeSlider states */
-  const [range, setRange]       = useState({ min: 20, max: 70 });
-  const [budget, setBudget]     = useState({ min: 120, max: 360 });
-  const [hours, setHours]       = useState({ min: 8, max: 18 });
-  const [rating, setRating]     = useState({ min: 3, max: 7 });
-  const [rtlRange, setRtlRange] = useState({ min: 30, max: 75 });
-  const [eventLog, setEventLog] = useState("Move a thumb to see callbacks.");
+  const [range,     setRange]     = useState({ min: 20,  max: 70  });
+  const [budget,    setBudget]    = useState({ min: 120, max: 360 });
+  const [hours,     setHours]     = useState({ min: 8,   max: 18  });
+  const [rating,    setRating]    = useState({ min: 3,   max: 7   });
+  const [rtlRange,  setRtlRange]  = useState({ min: 30,  max: 75  });
+  const [eventLog,  setEventLog]  = useState("Move a thumb to see callbacks.");
 
   /* SingleSlider states */
-  const [volume, setVolume]     = useState(65);
-  const [opacity, setOpacity]   = useState(80);
-  const [price, setPrice]       = useState(240);
+  const [volume,  setVolume]  = useState(65);
+  const [opacity, setOpacity] = useState(80);
+  const [price,   setPrice]   = useState(240);
 
   /* VerticalSlider states */
-  const [bass, setBass]         = useState(60);
-  const [mid, setMid]           = useState(45);
-  const [treble, setTreble]     = useState(70);
+  const [bass,   setBass]   = useState(60);
+  const [mid,    setMid]    = useState(45);
+  const [treble, setTreble] = useState(70);
 
   /* MultiPointSlider states */
-  const [stops, setStops]       = useState([15, 40, 65, 85]);
+  const [stops, setStops] = useState([15, 40, 65, 85]);
 
   /* CircularSlider states */
-  const [degrees, setDegrees]   = useState(135);
-  const [temp, setTemp]         = useState(22);
+  const [degrees,  setDegrees]  = useState(135);
+  const [temp,     setTemp]     = useState(22);
   const [progress, setProgress] = useState(65);
-  const [knob, setKnob]         = useState(300);
+  const [knob,     setKnob]     = useState(300);
 
   /* Scale / ruler demo states */
-  const [simpleRange,   setSimpleRange]   = useState({ min: 25, max: 75 });
-  const [weekRange,     setWeekRange]     = useState({ min: 1,  max: 5  });
-  const [dateRange,     setDateRange]     = useState({ min: 22, max: 364 });
-  const [timeRange,     setTimeRange]     = useState({ min: 619, max: 719 });
-  const [negRange,      setNegRange]      = useState({ min: -0.5, max: 0.5 });
-  const [stepRange,     setStepRange]     = useState({ min: 30, max: 60 });
+  const [simpleRange, setSimpleRange] = useState({ min: 25,  max: 75  });
+  const [weekRange,   setWeekRange]   = useState({ min: 1,   max: 5   });
+  const [dateRange,   setDateRange]   = useState({ min: 22,  max: 364 });
+  const [timeRange,   setTimeRange]   = useState({ min: 619, max: 719 });
+  const [negRange,    setNegRange]    = useState({ min: -0.5, max: 0.5 });
+  const [stepRange,   setStepRange]   = useState({ min: 30,  max: 60  });
 
   /* Theme demo states */
   const [tDefault,  setTDefault]  = useState({ min: 25, max: 75 });
@@ -88,11 +192,54 @@ export default function App() {
   const [tNeum,     setTNeum]     = useState({ min: 30, max: 70 });
   const [tDark,     setTDark]     = useState({ min: 35, max: 65 });
 
+  /* Active sidebar item */
+  const [activeId, setActiveId] = useState("install");
+
   const noop = useCallback(() => {}, []);
-  const install = useMemo(() => "npm install react-js-multi-range-sliders", []);
+
+  /* Scroll-spy: track which section is nearest to the top of the viewport */
+  useEffect(() => {
+    const allIds = NAV.flatMap((n) => [n.id, ...n.items.map((i) => i.id)]);
+
+    const onScroll = () => {
+      for (let i = allIds.length - 1; i >= 0; i--) {
+        const el = document.getElementById(allIds[i]);
+        if (el && el.getBoundingClientRect().top <= 100) {
+          setActiveId(allIds[i]);
+          return;
+        }
+      }
+      setActiveId(allIds[0]);
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
 
   return (
-    <main className="page-shell">
+    <div className="page-shell">
+
+      {/* ── TOP NAVBAR ─────────────────────────────────────────── */}
+      <header className="top-nav">
+        <div className="top-nav__brand">
+          <span className="top-nav__dot" />
+          react-js-multi-range-sliders
+        </div>
+        <div className="top-nav__actions">
+          <code className="top-nav__install">
+            npm install react-js-multi-range-sliders
+          </code>
+          <a
+            href="https://www.npmjs.com/package/react-js-multi-range-sliders"
+            className="top-nav__npm"
+            target="_blank"
+            rel="noreferrer"
+          >
+            npm
+          </a>
+        </div>
+      </header>
 
       {/* ── HERO ───────────────────────────────────────────────── */}
       <section className="hero-section">
@@ -108,16 +255,22 @@ export default function App() {
             <a href="#range-slider" className="primary-link">View examples</a>
             <a href="#install"      className="secondary-link">Install</a>
           </div>
+          <div className="hero-chips">
+            <span className="chip">TypeScript</span>
+            <span className="chip">Tree-shakeable</span>
+            <span className="chip">4 Themes</span>
+            <span className="chip">Accessible</span>
+            <span className="chip">Zero deps</span>
+          </div>
         </div>
-        <div className="hero-demo" aria-label="Live range slider preview">
+        <div className="hero-demo">
+          <p className="hero-demo__label">Live preview</p>
           <RangeSlider
-            min={0}
-            max={100}
+            min={0} max={100}
             value={range}
             onChange={setRange}
             minDistance={5}
-            showTooltip
-            showLabels
+            showTooltip showLabels
             trackColor="#e2e8f0"
             rangeColor="#2563eb"
             thumbColor="#ffffff"
@@ -128,101 +281,96 @@ export default function App() {
             <span>Selected range</span>
             <strong>{range.min} – {range.max}</strong>
           </div>
-          <div className="hero-chips">
-            <span className="chip">TypeScript</span>
-            <span className="chip">Tree-shakeable</span>
-            <span className="chip">4 Themes</span>
-            <span className="chip">Accessible</span>
-          </div>
         </div>
       </section>
 
-      {/* ── INSTALL ────────────────────────────────────────────── */}
-      <section className="quick-start" id="install">
-        <div>
-          <span className="demo-kicker">Quick start</span>
-          <h2>Install and import</h2>
-        </div>
-        <CodeBlock>{`${install}
+      {/* ── DOCS LAYOUT ────────────────────────────────────────── */}
+      <div className="docs-layout">
+        <main className="docs-main">
+
+          {/* ── QUICK START ──────────────────────────────────── */}
+          <section className="quick-start" id="install">
+            <SectionHeader
+              tag="Quick Start"
+              title="Install and import"
+              description={null}
+            />
+            <CodeBlock>{`npm install react-js-multi-range-sliders
 
 // Named imports — tree-shaken by your bundler
 import { RangeSlider, SingleSlider, VerticalSlider,
          MultiPointSlider, CircularSlider } from "react-js-multi-range-sliders";
 
 // Per-component import — zero bundler tree-shaking needed
-import RangeSlider from "react-js-multi-range-sliders/RangeSlider";`}
-        </CodeBlock>
-      </section>
+import RangeSlider from "react-js-multi-range-sliders/RangeSlider";`}</CodeBlock>
+          </section>
 
-      {/* ══════════════════════════════════════════════════════════
-          RANGE SLIDER
-      ══════════════════════════════════════════════════════════ */}
-      <div className="examples-layout" id="range-slider">
-        <SectionHeader
-          tag="Component"
-          title="RangeSlider"
-          description="Dual-thumb slider. onChange receives { min, max }."
-        />
+          {/* ══ RANGE SLIDER ═══════════════════════════════════ */}
+          <div className="examples-layout" id="range-slider">
+            <SectionHeader
+              tag="Component"
+              title="RangeSlider"
+              description="Dual-thumb slider. onChange receives { min, max }."
+            />
 
-        <DemoSection
-          id="controlled"
-          title="Controlled value"
-          description="Bind value to React state for full control over the selection."
-          meta={<strong>{range.min} – {range.max}</strong>}
-          code={`<RangeSlider
+            <DemoSection
+              id="controlled"
+              title="Controlled value"
+              description="Bind value to React state for full control over the selection."
+              meta={<strong>{range.min} – {range.max}</strong>}
+              code={`<RangeSlider
   min={0} max={100}
   value={range}
   onChange={setRange}
   minDistance={5}
   showTooltip
 />`}
-        >
-          <RangeSlider
-            min={0} max={100}
-            value={range}
-            onChange={setRange}
-            minDistance={5}
-            showTooltip
-            showLabels
-            trackColor="#e5e7eb"
-            rangeColor="#2563eb"
-            thumbColor="#ffffff"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
+            >
+              <RangeSlider
+                min={0} max={100}
+                value={range}
+                onChange={setRange}
+                minDistance={5}
+                showTooltip showLabels
+                trackColor="#e5e7eb"
+                rangeColor="#2563eb"
+                thumbColor="#ffffff"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
 
-        <DemoSection
-          id="budget"
-          title="Default value + step"
-          description="Uncontrolled with a step of 10 and a custom label formatter."
-          meta={<strong>${budget.min} – ${budget.max}</strong>}
-          code={`<RangeSlider
+            <DemoSection
+              id="budget"
+              title="Default value + step"
+              description="Uncontrolled with a step of 10 and a custom label formatter."
+              meta={<strong>${budget.min} – ${budget.max}</strong>}
+              code={`<RangeSlider
   min={0} max={500} step={10}
   defaultValue={{ min: 120, max: 360 }}
   onChange={setBudget}
   formatLabel={(v) => \`$\${v}\`}
   showTooltip showLabels
 />`}
-        >
-          <RangeSlider
-            min={0} max={500} step={10}
-            defaultValue={{ min: 120, max: 360 }}
-            onChange={setBudget}
-            formatLabel={(v) => `$${v}`}
-            showTooltip showLabels
-            trackColor="#dbe4ea"
-            rangeColor="#0f766e"
-            thumbColor="#ffffff"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
+            >
+              <RangeSlider
+                min={0} max={500} step={10}
+                defaultValue={{ min: 120, max: 360 }}
+                onChange={setBudget}
+                formatLabel={(v) => `$${v}`}
+                showTooltip showLabels
+                trackColor="#dbe4ea"
+                rangeColor="#0f766e"
+                thumbColor="#ffffff"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
 
-        <DemoSection
-          id="booking"
-          title="Minimum distance"
-          description="minDistance keeps the thumbs at least N steps apart."
-          meta={<strong>{hours.min}:00 – {hours.max}:00</strong>}
-          code={`<RangeSlider
+            <DemoSection
+              id="booking"
+              title="Minimum distance"
+              description="minDistance keeps the thumbs at least N steps apart."
+              meta={<strong>{hours.min}:00 – {hours.max}:00</strong>}
+              code={`<RangeSlider
   min={0} max={24}
   value={hours}
   onChange={setHours}
@@ -230,143 +378,143 @@ import RangeSlider from "react-js-multi-range-sliders/RangeSlider";`}
   formatLabel={(v) => \`\${v}:00\`}
   showTooltip
 />`}
-        >
-          <RangeSlider
-            min={0} max={24}
-            value={hours}
-            onChange={setHours}
-            minDistance={4}
-            formatLabel={(v) => `${v}:00`}
-            showTooltip showLabels
-            trackColor="#e5e7eb"
-            rangeColor="#b45309"
-            thumbColor="#fff7ed"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
+            >
+              <RangeSlider
+                min={0} max={24}
+                value={hours}
+                onChange={setHours}
+                minDistance={4}
+                formatLabel={(v) => `${v}:00`}
+                showTooltip showLabels
+                trackColor="#e5e7eb"
+                rangeColor="#b45309"
+                thumbColor="#fff7ed"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
 
-        <DemoSection
-          id="overlap"
-          title="Allow overlap"
-          description="allowOverlap lets both thumbs meet at the same value."
-          meta={<strong>{rating.min} – {rating.max}</strong>}
-          code={`<RangeSlider
+            <DemoSection
+              id="overlap"
+              title="Allow overlap"
+              description="allowOverlap lets both thumbs meet at the same value."
+              meta={<strong>{rating.min} – {rating.max}</strong>}
+              code={`<RangeSlider
   min={0} max={10}
   value={rating}
   onChange={setRating}
   allowOverlap
   showTooltip
 />`}
-        >
-          <RangeSlider
-            min={0} max={10}
-            value={rating}
-            onChange={setRating}
-            allowOverlap
-            showTooltip showLabels
-            trackColor="#e2e8f0"
-            rangeColor="#7c3aed"
-            thumbColor="#ffffff"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
+            >
+              <RangeSlider
+                min={0} max={10}
+                value={rating}
+                onChange={setRating}
+                allowOverlap
+                showTooltip showLabels
+                trackColor="#e2e8f0"
+                rangeColor="#7c3aed"
+                thumbColor="#ffffff"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
 
-        <DemoSection
-          id="rtl"
-          title="RTL direction"
-          description="direction=rtl flips interaction and labels for Arabic / Hebrew layouts."
-          meta={<strong>{rtlRange.min} – {rtlRange.max}</strong>}
-          code={`<RangeSlider
+            <DemoSection
+              id="rtl"
+              title="RTL direction"
+              description="direction=rtl flips interaction and labels for Arabic / Hebrew layouts."
+              meta={<strong>{rtlRange.min} – {rtlRange.max}</strong>}
+              code={`<RangeSlider
   min={0} max={100}
   value={rtlRange}
   onChange={setRtlRange}
   direction="rtl"
   showTooltip
 />`}
-        >
-          <RangeSlider
-            min={0} max={100}
-            value={rtlRange}
-            onChange={setRtlRange}
-            direction="rtl"
-            showTooltip showLabels
-            trackColor="#e5e7eb"
-            rangeColor="#db2777"
-            thumbColor="#ffffff"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
+            >
+              <RangeSlider
+                min={0} max={100}
+                value={rtlRange}
+                onChange={setRtlRange}
+                direction="rtl"
+                showTooltip showLabels
+                trackColor="#e5e7eb"
+                rangeColor="#db2777"
+                thumbColor="#ffffff"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
 
-        <DemoSection
-          id="disabled"
-          title="Disabled"
-          description="Render a read-only range without removing it from context."
-          meta={<strong>25 – 80</strong>}
-          code={`<RangeSlider
+            <DemoSection
+              id="disabled"
+              title="Disabled"
+              description="Render a read-only range without removing it from context."
+              meta={<strong>25 – 80</strong>}
+              code={`<RangeSlider
   min={0} max={100}
   defaultValue={{ min: 25, max: 80 }}
   onChange={noop}
   disabled showLabels
 />`}
-        >
-          <RangeSlider
-            min={0} max={100}
-            defaultValue={{ min: 25, max: 80 }}
-            onChange={noop}
-            disabled showLabels
-            trackColor="#e5e7eb"
-            rangeColor="#94a3b8"
-            thumbColor="#f8fafc"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
+            >
+              <RangeSlider
+                min={0} max={100}
+                defaultValue={{ min: 25, max: 80 }}
+                onChange={noop}
+                disabled showLabels
+                trackColor="#e5e7eb"
+                rangeColor="#94a3b8"
+                thumbColor="#f8fafc"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
 
-        <section className="demo-section" id="callbacks">
-          <div className="demo-copy">
-            <h3>Callbacks</h3>
-            <p>onChangeStart fires on pointer-down; onChangeComplete fires on release.</p>
-            <div className="demo-meta"><strong>{eventLog}</strong></div>
-          </div>
-          <div className="demo-panel">
-            <RangeSlider
-              min={0} max={100}
-              defaultValue={{ min: 15, max: 85 }}
-              onChange={noop}
-              onChangeStart={(v) => setEventLog(`Started  ${v.min} – ${v.max}`)}
-              onChangeComplete={(v) => setEventLog(`Finished ${v.min} – ${v.max}`)}
-              showTooltip showLabels
-              trackColor="#e5e7eb"
-              rangeColor="#059669"
-              thumbColor="#ffffff"
-              style={{ width: "100%" }}
-            />
-          </div>
-          <CodeBlock>{`<RangeSlider
+            <section className="demo-section" id="callbacks">
+              <div className="demo-left">
+                <h3 className="demo-title">Callbacks</h3>
+                <p className="demo-desc">
+                  onChangeStart fires on pointer-down; onChangeComplete fires on release.
+                </p>
+                <div className="demo-meta"><strong>{eventLog}</strong></div>
+                <div className="demo-panel">
+                  <RangeSlider
+                    min={0} max={100}
+                    defaultValue={{ min: 15, max: 85 }}
+                    onChange={noop}
+                    onChangeStart={(v) => setEventLog(`Started  ${v.min} – ${v.max}`)}
+                    onChangeComplete={(v) => setEventLog(`Finished ${v.min} – ${v.max}`)}
+                    showTooltip showLabels
+                    trackColor="#e5e7eb"
+                    rangeColor="#059669"
+                    thumbColor="#ffffff"
+                    style={{ width: "100%" }}
+                  />
+                </div>
+              </div>
+              <CodeBlock>{`<RangeSlider
   min={0} max={100}
   defaultValue={{ min: 15, max: 85 }}
   onChange={() => {}}
   onChangeStart={(v) => console.log("start", v)}
   onChangeComplete={(v) => console.log("done",  v)}
 />`}</CodeBlock>
-        </section>
-      </div>
+            </section>
+          </div>
 
-      {/* ══════════════════════════════════════════════════════════
-          SINGLE SLIDER
-      ══════════════════════════════════════════════════════════ */}
-      <div className="examples-layout" id="single-slider">
-        <SectionHeader
-          tag="Component"
-          title="SingleSlider"
-          description="Single thumb. onChange receives a number."
-        />
+          {/* ══ SINGLE SLIDER ══════════════════════════════════ */}
+          <div className="examples-layout" id="single-slider">
+            <SectionHeader
+              tag="Component"
+              title="SingleSlider"
+              description="Single thumb. onChange receives a number."
+            />
 
-        <DemoSection
-          id="volume"
-          title="Basic"
-          description="Single thumb with min/max labels and a live value display."
-          meta={<strong>Volume: {volume}%</strong>}
-          code={`import { SingleSlider } from "react-js-multi-range-sliders";
+            <DemoSection
+              id="volume"
+              title="Basic"
+              description="Single thumb with min/max labels and a live value display."
+              meta={<strong>Volume: {volume}%</strong>}
+              code={`import { SingleSlider } from "react-js-multi-range-sliders";
 
 <SingleSlider
   min={0} max={100}
@@ -374,51 +522,51 @@ import RangeSlider from "react-js-multi-range-sliders/RangeSlider";`}
   onChange={setVolume}
   showLabels
 />`}
-        >
-          <SingleSlider
-            min={0} max={100}
-            value={volume}
-            onChange={setVolume}
-            showLabels
-            trackColor="#e5e7eb"
-            rangeColor="#2563eb"
-            thumbColor="#ffffff"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
+            >
+              <SingleSlider
+                min={0} max={100}
+                value={volume}
+                onChange={setVolume}
+                showLabels
+                trackColor="#e5e7eb"
+                rangeColor="#2563eb"
+                thumbColor="#ffffff"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
 
-        <DemoSection
-          id="opacity"
-          title="With tooltip"
-          description="showTooltip displays the current value above the thumb while dragging."
-          meta={<strong>Opacity: {opacity}%</strong>}
-          code={`<SingleSlider
+            <DemoSection
+              id="opacity"
+              title="With tooltip"
+              description="showTooltip displays the current value above the thumb."
+              meta={<strong>Opacity: {opacity}%</strong>}
+              code={`<SingleSlider
   min={0} max={100}
   value={opacity}
   onChange={setOpacity}
   showTooltip showLabels
   formatLabel={(v) => \`\${v}%\`}
 />`}
-        >
-          <SingleSlider
-            min={0} max={100}
-            value={opacity}
-            onChange={setOpacity}
-            showTooltip showLabels
-            formatLabel={(v) => `${v}%`}
-            trackColor="#e5e7eb"
-            rangeColor="#7c3aed"
-            thumbColor="#ffffff"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
+            >
+              <SingleSlider
+                min={0} max={100}
+                value={opacity}
+                onChange={setOpacity}
+                showTooltip showLabels
+                formatLabel={(v) => `${v}%`}
+                trackColor="#e5e7eb"
+                rangeColor="#7c3aed"
+                thumbColor="#ffffff"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
 
-        <DemoSection
-          id="price"
-          title="Custom label + step"
-          description="formatLabel formats both the tooltip and the labels."
-          meta={<strong>Max price: ${price}</strong>}
-          code={`<SingleSlider
+            <DemoSection
+              id="price"
+              title="Custom label + step"
+              description="formatLabel formats both the tooltip and the labels."
+              meta={<strong>Max price: ${price}</strong>}
+              code={`<SingleSlider
   min={0} max={1000} step={10}
   value={price}
   onChange={setPrice}
@@ -426,75 +574,58 @@ import RangeSlider from "react-js-multi-range-sliders/RangeSlider";`}
   formatLabel={(v) => \`$\${v}\`}
   theme="material"
 />`}
-        >
-          <SingleSlider
-            min={0} max={1000} step={10}
-            value={price}
-            onChange={setPrice}
-            showTooltip showLabels
-            formatLabel={(v) => `$${v}`}
-            theme="material"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
-      </div>
-
-      {/* ══════════════════════════════════════════════════════════
-          VERTICAL SLIDER
-      ══════════════════════════════════════════════════════════ */}
-      <div className="examples-layout" id="vertical-slider">
-        <SectionHeader
-          tag="Component"
-          title="VerticalSlider"
-          description="Vertical orientation. Works cross-browser (Chrome, Firefox, Safari)."
-        />
-
-        <section className="demo-section demo-section--vertical" id="equalizer">
-          <div className="demo-copy">
-            <h3>Equalizer</h3>
-            <p>Three vertical sliders side by side, each controlling an independent value.</p>
-            <div className="demo-meta">
-              <strong>Bass {bass} · Mid {mid} · Treble {treble}</strong>
-            </div>
+            >
+              <SingleSlider
+                min={0} max={1000} step={10}
+                value={price}
+                onChange={setPrice}
+                showTooltip showLabels
+                formatLabel={(v) => `$${v}`}
+                theme="material"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
           </div>
-          <div className="demo-panel demo-panel--vertical">
-            <div className="eq-row">
-              <div className="eq-channel">
-                <VerticalSlider
-                  min={0} max={100} height={160}
-                  value={bass}
-                  onChange={setBass}
-                  showTooltip showLabels
-                  rangeColor="#2563eb"
-                  thumbColor="#ffffff"
-                />
-                <span className="eq-label">Bass</span>
+
+          {/* ══ VERTICAL SLIDER ════════════════════════════════ */}
+          <div className="examples-layout" id="vertical-slider">
+            <SectionHeader
+              tag="Component"
+              title="VerticalSlider"
+              description="Vertical orientation. Works cross-browser (Chrome, Firefox, Safari)."
+            />
+
+            <section className="demo-section demo-section--compact" id="equalizer">
+              <div className="demo-left">
+                <h3 className="demo-title">Equalizer</h3>
+                <p className="demo-desc">
+                  Three vertical sliders side by side, each controlling an independent value.
+                </p>
+                <div className="demo-meta">
+                  <strong>Bass {bass} · Mid {mid} · Treble {treble}</strong>
+                </div>
+                <div className="demo-panel">
+                  <div className="eq-row">
+                    {[
+                      { val: bass,   set: setBass,   color: "#2563eb", label: "Bass"   },
+                      { val: mid,    set: setMid,    color: "#7c3aed", label: "Mid"    },
+                      { val: treble, set: setTreble, color: "#0f766e", label: "Treble" },
+                    ].map(({ val, set, color, label }) => (
+                      <div className="eq-channel" key={label}>
+                        <VerticalSlider
+                          min={0} max={100} height={160}
+                          value={val} onChange={set}
+                          showTooltip showLabels
+                          rangeColor={color}
+                          thumbColor="#ffffff"
+                        />
+                        <span className="eq-label">{label}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
               </div>
-              <div className="eq-channel">
-                <VerticalSlider
-                  min={0} max={100} height={160}
-                  value={mid}
-                  onChange={setMid}
-                  showTooltip showLabels
-                  rangeColor="#7c3aed"
-                  thumbColor="#ffffff"
-                />
-                <span className="eq-label">Mid</span>
-              </div>
-              <div className="eq-channel">
-                <VerticalSlider
-                  min={0} max={100} height={160}
-                  value={treble}
-                  onChange={setTreble}
-                  showTooltip showLabels
-                  rangeColor="#0f766e"
-                  thumbColor="#ffffff"
-                />
-                <span className="eq-label">Treble</span>
-              </div>
-            </div>
-          </div>
-          <CodeBlock>{`import { VerticalSlider } from "react-js-multi-range-sliders";
+              <CodeBlock>{`import { VerticalSlider } from "react-js-multi-range-sliders";
 
 <VerticalSlider
   min={0} max={100}
@@ -503,59 +634,57 @@ import RangeSlider from "react-js-multi-range-sliders/RangeSlider";`}
   onChange={setBass}
   showTooltip showLabels
 />`}</CodeBlock>
-        </section>
+            </section>
 
-        <section className="demo-section demo-section--vertical" id="vertical-themes">
-          <div className="demo-copy">
-            <h3>Themes</h3>
-            <p>Vertical sliders support all four built-in themes.</p>
-          </div>
-          <div className="demo-panel demo-panel--vertical">
-            <div className="eq-row">
-              {[
-                { theme: "default",    label: "Default",    val: 50  },
-                { theme: "material",   label: "Material",   val: 65  },
-                { theme: "neumorphic", label: "Neumorphic", val: 40  },
-                { theme: "dark",       label: "Dark",       val: 75  },
-              ].map(({ theme, label, val }) => (
-                <div className="eq-channel" key={theme}>
-                  <VerticalSlider
-                    min={0} max={100} height={140}
-                    defaultValue={val}
-                    onChange={noop}
-                    theme={theme}
-                    showLabels
-                  />
-                  <span className="eq-label">{label}</span>
+            <section className="demo-section demo-section--compact" id="vertical-themes">
+              <div className="demo-left">
+                <h3 className="demo-title">Themes</h3>
+                <p className="demo-desc">Vertical sliders support all four built-in themes.</p>
+                <div className="demo-panel">
+                  <div className="eq-row">
+                    {[
+                      { theme: "default",    label: "Default",    val: 50 },
+                      { theme: "material",   label: "Material",   val: 65 },
+                      { theme: "neumorphic", label: "Neumorphic", val: 40 },
+                      { theme: "dark",       label: "Dark",       val: 75 },
+                    ].map(({ theme, label, val }) => (
+                      <div className="eq-channel" key={theme}>
+                        <VerticalSlider
+                          min={0} max={100} height={140}
+                          defaultValue={val}
+                          onChange={noop}
+                          theme={theme}
+                          showLabels
+                        />
+                        <span className="eq-label">{label}</span>
+                      </div>
+                    ))}
+                  </div>
                 </div>
-              ))}
-            </div>
-          </div>
-          <CodeBlock>{`<VerticalSlider
+              </div>
+              <CodeBlock>{`<VerticalSlider
   min={0} max={100} height={140}
   defaultValue={65}
   onChange={fn}
   theme="material"   // "default" | "material" | "neumorphic" | "dark"
 />`}</CodeBlock>
-        </section>
-      </div>
+            </section>
+          </div>
 
-      {/* ══════════════════════════════════════════════════════════
-          MULTI-POINT SLIDER
-      ══════════════════════════════════════════════════════════ */}
-      <div className="examples-layout" id="multi-point">
-        <SectionHeader
-          tag="Component"
-          title="MultiPointSlider"
-          description="N independent thumbs. onChange receives a sorted number[]."
-        />
+          {/* ══ MULTI-POINT SLIDER ═════════════════════════════ */}
+          <div className="examples-layout" id="multi-point">
+            <SectionHeader
+              tag="Component"
+              title="MultiPointSlider"
+              description="N independent thumbs. onChange receives a sorted number[]."
+            />
 
-        <DemoSection
-          id="price-range"
-          title="Four-stop price filter"
-          description="Four thumbs divide the range into three coloured segments."
-          meta={<strong>{stops.map((v) => `$${v}`).join(" – ")}</strong>}
-          code={`import { MultiPointSlider } from "react-js-multi-range-sliders";
+            <DemoSection
+              id="price-range"
+              title="Four-stop price filter"
+              description="Four thumbs divide the range into three coloured segments."
+              meta={<strong>{stops.map((v) => `$${v}`).join(" – ")}</strong>}
+              code={`import { MultiPointSlider } from "react-js-multi-range-sliders";
 
 <MultiPointSlider
   min={0} max={100}
@@ -564,27 +693,27 @@ import RangeSlider from "react-js-multi-range-sliders/RangeSlider";`}
   minDistance={5}
   showTooltip showLabels
 />`}
-        >
-          <MultiPointSlider
-            min={0} max={100}
-            values={stops}
-            onChange={setStops}
-            minDistance={5}
-            showTooltip showLabels
-            formatLabel={(v) => `$${v}`}
-            trackColor="#e5e7eb"
-            rangeColor="#2563eb"
-            thumbColor="#ffffff"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
+            >
+              <MultiPointSlider
+                min={0} max={100}
+                values={stops}
+                onChange={setStops}
+                minDistance={5}
+                showTooltip showLabels
+                formatLabel={(v) => `$${v}`}
+                trackColor="#e5e7eb"
+                rangeColor="#2563eb"
+                thumbColor="#ffffff"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
 
-        <DemoSection
-          id="multipoint-material"
-          title="Material theme"
-          description="Three thumbs in material style — fixed, not controlled."
-          meta={null}
-          code={`<MultiPointSlider
+            <DemoSection
+              id="multipoint-material"
+              title="Material theme"
+              description="Three thumbs in material style — fixed, not controlled."
+              meta={null}
+              code={`<MultiPointSlider
   min={0} max={100}
   defaultValues={[20, 50, 80]}
   onChange={fn}
@@ -592,152 +721,112 @@ import RangeSlider from "react-js-multi-range-sliders/RangeSlider";`}
   showTooltip
   theme="material"
 />`}
-        >
-          <MultiPointSlider
-            min={0} max={100}
-            defaultValues={[20, 50, 80]}
-            onChange={noop}
-            minDistance={10}
-            showTooltip showLabels
-            theme="material"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
-      </div>
-
-      {/* ══════════════════════════════════════════════════════════
-          CIRCULAR SLIDER
-      ══════════════════════════════════════════════════════════ */}
-      <div className="examples-layout" id="circular-slider">
-        <SectionHeader
-          tag="Component"
-          title="CircularSlider"
-          description="SVG radial knob. Draggable with mouse and touch. Keyboard accessible (←→↑↓ Home End)."
-        />
-
-        <section className="demo-section demo-section--circular" id="circular-demos">
-          <div className="demo-copy">
-            <h3>All four themes</h3>
-            <p>
-              Size, strokeWidth, formatLabel, and all four themes are shown
-              here. Full keyboard support — click the knob and use arrow keys.
-            </p>
+            >
+              <MultiPointSlider
+                min={0} max={100}
+                defaultValues={[20, 50, 80]}
+                onChange={noop}
+                minDistance={10}
+                showTooltip showLabels
+                theme="material"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
           </div>
-          <div className="demo-panel demo-panel--circular">
-            <div className="circular-grid">
-              <div className="circular-item">
-                <CircularSlider
-                  min={0} max={360}
-                  value={degrees}
-                  onChange={setDegrees}
-                  size={140}
-                  strokeWidth={12}
-                  formatLabel={(v) => `${v}°`}
-                  showLabel
-                  theme="default"
-                />
-                <span className="circular-label">Default</span>
+
+          {/* ══ CIRCULAR SLIDER ════════════════════════════════ */}
+          <div className="examples-layout" id="circular-slider">
+            <SectionHeader
+              tag="Component"
+              title="CircularSlider"
+              description="SVG radial knob. Draggable with mouse and touch. Keyboard accessible (←→↑↓ Home End)."
+            />
+
+            <section className="demo-section demo-section--compact" id="circular-demos">
+              <div className="demo-left">
+                <h3 className="demo-title">All four themes</h3>
+                <p className="demo-desc">
+                  Full keyboard support — click the knob and use arrow keys.
+                </p>
+                <div className="demo-panel">
+                  <div className="circular-grid">
+                    {[
+                      { label: "Default",    theme: "default",    min: 0,  max: 360, val: degrees,  set: setDegrees,  fmt: (v) => `${v}°`,   sw: 12 },
+                      { label: "Material",   theme: "material",   min: 16, max: 32,  val: temp,     set: setTemp,     fmt: (v) => `${v}°C`,  sw: 14 },
+                      { label: "Neumorphic", theme: "neumorphic", min: 0,  max: 100, val: progress, set: setProgress, fmt: (v) => `${v}%`,   sw: 14 },
+                      { label: "Dark",       theme: "dark",       min: 0,  max: 400, val: knob,     set: setKnob,     fmt: (v) => `${v}W`,   sw: 12 },
+                    ].map(({ label, theme, min, max, val, set, fmt, sw }) => (
+                      <div className="circular-item" key={theme}>
+                        <CircularSlider
+                          min={min} max={max}
+                          value={val} onChange={set}
+                          size={120} strokeWidth={sw}
+                          formatLabel={fmt}
+                          showLabel theme={theme}
+                        />
+                        <span className="circular-label">{label}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
               </div>
-              <div className="circular-item">
-                <CircularSlider
-                  min={16} max={32}
-                  value={temp}
-                  onChange={setTemp}
-                  size={140}
-                  strokeWidth={14}
-                  formatLabel={(v) => `${v}°C`}
-                  showLabel
-                  theme="material"
-                />
-                <span className="circular-label">Material</span>
-              </div>
-              <div className="circular-item">
-                <CircularSlider
-                  min={0} max={100}
-                  value={progress}
-                  onChange={setProgress}
-                  size={140}
-                  strokeWidth={14}
-                  formatLabel={(v) => `${v}%`}
-                  showLabel
-                  theme="neumorphic"
-                />
-                <span className="circular-label">Neumorphic</span>
-              </div>
-              <div className="circular-item">
-                <CircularSlider
-                  min={0} max={400}
-                  value={knob}
-                  onChange={setKnob}
-                  size={140}
-                  strokeWidth={12}
-                  formatLabel={(v) => `${v}W`}
-                  showLabel
-                  theme="dark"
-                />
-                <span className="circular-label">Dark</span>
-              </div>
-            </div>
-          </div>
-          <CodeBlock>{`import { CircularSlider } from "react-js-multi-range-sliders";
+              <CodeBlock>{`import { CircularSlider } from "react-js-multi-range-sliders";
 
 <CircularSlider
   min={0} max={100}
   value={progress}
   onChange={setProgress}
-  size={140}
-  strokeWidth={14}
+  size={140} strokeWidth={14}
   formatLabel={(v) => \`\${v}%\`}
   showLabel
   theme="neumorphic"  // "default" | "material" | "neumorphic" | "dark"
 />`}</CodeBlock>
-        </section>
-      </div>
+            </section>
+          </div>
 
-      {/* ══════════════════════════════════════════════════════════
-          SCALE SLIDER — ruler + labels + subSteps
-      ══════════════════════════════════════════════════════════ */}
-      <div className="examples-layout" id="scale-slider">
-        <SectionHeader
-          tag="Feature"
-          title="Scale Slider"
-          description="Add a ruler and/or evenly-spaced labels below any slider using the labels, ruler, and subSteps props."
-        />
+          {/* ══ SCALE SLIDER ═══════════════════════════════════ */}
+          <div className="examples-layout" id="scale-slider">
+            <SectionHeader
+              tag="Feature"
+              title="Scale Slider"
+              description="Add a ruler and/or evenly-spaced labels below any slider using the labels, ruler, and subSteps props."
+            />
 
-        {/* 1 ── Simple range with auto ruler */}
-        <DemoSection
-          id="scale-simple"
-          title="Simple range slider with default values"
-          description="ruler automatically generates 20 evenly-spaced tick marks. No custom labels needed."
-          meta={<strong>onInput: &nbsp;{simpleRange.min} &nbsp; {simpleRange.max}</strong>}
-          code={`<RangeSlider
+            <DemoSection
+              id="scale-simple"
+              title="Simple range slider with default values"
+              description="ruler automatically generates 20 evenly-spaced tick marks."
+              meta={<strong>onInput: {simpleRange.min} – {simpleRange.max}</strong>}
+              code={`<RangeSlider
   min={0} max={100}
   defaultValue={{ min: 25, max: 75 }}
   onChange={setSimpleRange}
-  ruler
-  showLabels
+  ruler showLabels
 />`}
-        >
-          <RangeSlider
-            min={0} max={100}
-            defaultValue={{ min: 25, max: 75 }}
-            onChange={setSimpleRange}
-            ruler
-            showLabels
-            trackColor="#dde3ea"
-            rangeColor="#4a9a4a"
-            thumbColor="#ffffff"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
+            >
+              <RangeSlider
+                min={0} max={100}
+                defaultValue={{ min: 25, max: 75 }}
+                onChange={setSimpleRange}
+                ruler showLabels
+                trackColor="#dde3ea"
+                rangeColor="#4a9a4a"
+                thumbColor="#ffffff"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
 
-        {/* 2 ── Week days */}
-        <DemoSection
-          id="scale-weekdays"
-          title="Range slider for week days"
-          description="Provide a labels array to render named tick positions. formatLabel maps the index to its label."
-          meta={<strong>onInput: &nbsp;{weekRange.min}:{["Sun","Mon","Tue","Wed","Thu","Fri","Sat"][weekRange.min]} &nbsp; {weekRange.max}:{["Sun","Mon","Tue","Wed","Thu","Fri","Sat"][weekRange.max]}</strong>}
-          code={`const DAYS = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
+            <DemoSection
+              id="scale-weekdays"
+              title="Range slider for week days"
+              description="Provide a labels array to render named tick positions."
+              meta={
+                <strong>
+                  {["Sun","Mon","Tue","Wed","Thu","Fri","Sat"][weekRange.min]} –{" "}
+                  {["Sun","Mon","Tue","Wed","Thu","Fri","Sat"][weekRange.max]}
+                </strong>
+              }
+              code={`const DAYS = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
 
 <RangeSlider
   min={0} max={6} step={1}
@@ -746,48 +835,36 @@ import RangeSlider from "react-js-multi-range-sliders/RangeSlider";`}
   labels={DAYS}
   formatLabel={(v) => DAYS[v]}
   showTooltip
-  showLabels={false}
 />`}
-        >
-          {(() => {
-            const DAYS = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
-            return (
-              <RangeSlider
-                min={0} max={6} step={1}
-                defaultValue={{ min: 1, max: 5 }}
-                onChange={setWeekRange}
-                labels={DAYS}
-                formatLabel={(v) => DAYS[v]}
-                showTooltip
-                showLabels={false}
-                trackColor="#dde3ea"
-                rangeColor="#4a9a4a"
-                thumbColor="#ffffff"
-                style={{ width: "100%" }}
-              />
-            );
-          })()}
-        </DemoSection>
+            >
+              {(() => {
+                const DAYS = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
+                return (
+                  <RangeSlider
+                    min={0} max={6} step={1}
+                    defaultValue={{ min: 1, max: 5 }}
+                    onChange={setWeekRange}
+                    labels={DAYS}
+                    formatLabel={(v) => DAYS[v]}
+                    showTooltip showLabels={false}
+                    trackColor="#dde3ea"
+                    rangeColor="#4a9a4a"
+                    thumbColor="#ffffff"
+                    style={{ width: "100%" }}
+                  />
+                );
+              })()}
+            </DemoSection>
 
-        {/* 3 ── Date range */}
-        <DemoSection
-          id="scale-daterange"
-          title="Range slider for date range"
-          description="Month labels with a custom formatLabel that converts a day-of-year index to a human-readable date."
-          meta={<strong>onInput: &nbsp;{dateRange.min} &nbsp; {dateRange.max}</strong>}
-          code={`const MONTHS = ["Jan","Feb","Mar","Apr","May","Jun",
+            <DemoSection
+              id="scale-daterange"
+              title="Range slider for date range"
+              description="Month labels with a custom formatLabel converting day-of-year to a human-readable date."
+              meta={<strong>onInput: {dateRange.min} – {dateRange.max}</strong>}
+              code={`const MONTHS = ["Jan","Feb","Mar","Apr","May","Jun",
                  "Jul","Aug","Sep","Oct","Nov","Dec"];
 
-// Simple day-of-year → month label helper
-const dayLabel = (d) => {
-  const mDays = [31,31,28,31,30,31,30,31,31,30,31,30,31];
-  let acc = 0;
-  for (let m = 0; m < 12; m++) {
-    acc += mDays[m];
-    if (d <= acc) return MONTHS[m];
-  }
-  return "Dec";
-};
+const dayLabel = (d) => { /* day-of-year → month */ };
 
 <RangeSlider
   min={0} max={365}
@@ -796,42 +873,44 @@ const dayLabel = (d) => {
   labels={MONTHS}
   formatLabel={dayLabel}
   showTooltip
-  showLabels={false}
 />`}
-        >
-          {(() => {
-            const MONTHS = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
-            const mDays  = [31,31,28,31,30,31,30,31,31,30,31,30,31];
-            const dayLabel = (d) => {
-              let acc = 0;
-              for (let m = 0; m < 12; m++) { acc += mDays[m]; if (d <= acc) return MONTHS[m]; }
-              return "Dec";
-            };
-            return (
-              <RangeSlider
-                min={0} max={365}
-                defaultValue={{ min: 22, max: 364 }}
-                onChange={setDateRange}
-                labels={MONTHS}
-                formatLabel={dayLabel}
-                showTooltip
-                showLabels={false}
-                trackColor="#dde3ea"
-                rangeColor="#4a9a4a"
-                thumbColor="#ffffff"
-                style={{ width: "100%" }}
-              />
-            );
-          })()}
-        </DemoSection>
+            >
+              {(() => {
+                const MONTHS = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+                const mDays  = [31,31,28,31,30,31,30,31,31,30,31,30,31];
+                const dayLabel = (d) => {
+                  let acc = 0;
+                  for (let m = 0; m < 12; m++) { acc += mDays[m]; if (d <= acc) return MONTHS[m]; }
+                  return "Dec";
+                };
+                return (
+                  <RangeSlider
+                    min={0} max={365}
+                    defaultValue={{ min: 22, max: 364 }}
+                    onChange={setDateRange}
+                    labels={MONTHS}
+                    formatLabel={dayLabel}
+                    showTooltip showLabels={false}
+                    trackColor="#dde3ea"
+                    rangeColor="#4a9a4a"
+                    thumbColor="#ffffff"
+                    style={{ width: "100%" }}
+                  />
+                );
+              })()}
+            </DemoSection>
 
-        {/* 4 ── Time range with subSteps */}
-        <DemoSection
-          id="scale-time"
-          title="Time-Range with subSteps"
-          description="subSteps={true} inserts 3 minor ticks between each hour label (15-minute intervals)."
-          meta={<strong>onInput: &nbsp;{Math.floor(timeRange.min/60)}:{String(timeRange.min%60).padStart(2,"0")} &nbsp; {Math.floor(timeRange.max/60)}:{String(timeRange.max%60).padStart(2,"0")}</strong>}
-          code={`const HOURS = Array.from({ length: 13 }, (_, i) =>
+            <DemoSection
+              id="scale-time"
+              title="Time-Range with subSteps"
+              description="subSteps={true} inserts 3 minor ticks between each hour label (15-minute intervals)."
+              meta={
+                <strong>
+                  {Math.floor(timeRange.min/60)}:{String(timeRange.min%60).padStart(2,"0")} –{" "}
+                  {Math.floor(timeRange.max/60)}:{String(timeRange.max%60).padStart(2,"0")}
+                </strong>
+              }
+              code={`const HOURS = Array.from({ length: 13 }, (_, i) =>
   String(i).padStart(2,"0") + ":00"
 );
 
@@ -845,143 +924,140 @@ const fmtTime = (v) => {
   min={0} max={719} step={1}
   defaultValue={{ min: 619, max: 719 }}
   onChange={setTimeRange}
-  labels={HOURS}
-  subSteps={true}
+  labels={HOURS} subSteps={true}
   formatLabel={fmtTime}
   showTooltip
-  showLabels={false}
 />`}
-        >
-          {(() => {
-            const HOURS = Array.from({ length: 13 }, (_, i) => String(i).padStart(2,"0") + ":00");
-            const fmtTime = (v) => {
-              const h = Math.floor(v / 60);
-              const m = v % 60;
-              return `${String(h).padStart(2,"0")}:${String(m).padStart(2,"0")}`;
-            };
-            return (
+            >
+              {(() => {
+                const HOURS = Array.from({ length: 13 }, (_, i) => String(i).padStart(2,"0") + ":00");
+                const fmtTime = (v) => {
+                  const h = Math.floor(v / 60);
+                  const m = v % 60;
+                  return `${String(h).padStart(2,"0")}:${String(m).padStart(2,"0")}`;
+                };
+                return (
+                  <RangeSlider
+                    min={0} max={719} step={1}
+                    defaultValue={{ min: 619, max: 719 }}
+                    onChange={setTimeRange}
+                    labels={HOURS}
+                    subSteps={true}
+                    formatLabel={fmtTime}
+                    showTooltip showLabels={false}
+                    trackColor="#dde3ea"
+                    rangeColor="#4a9a4a"
+                    thumbColor="#ffffff"
+                    style={{ width: "100%" }}
+                  />
+                );
+              })()}
+            </DemoSection>
+
+            <DemoSection
+              id="scale-negative"
+              title="Negative and positive range"
+              description="The ruler works across negative ranges. step={0.1} gives 20 auto ticks between -1 and 1."
+              meta={<strong>onInput: {negRange.min.toFixed(1)} – {negRange.max.toFixed(1)}</strong>}
+              code={`<RangeSlider
+  min={-1} max={1} step={0.1}
+  defaultValue={{ min: -0.5, max: 0.5 }}
+  onChange={setNegRange}
+  ruler showLabels
+  formatLabel={(v) => v.toFixed(1)}
+/>`}
+            >
               <RangeSlider
-                min={0} max={719} step={1}
-                defaultValue={{ min: 619, max: 719 }}
-                onChange={setTimeRange}
-                labels={HOURS}
-                subSteps={true}
-                formatLabel={fmtTime}
-                showTooltip
-                showLabels={false}
+                min={-1} max={1} step={0.1}
+                defaultValue={{ min: -0.5, max: 0.5 }}
+                onChange={setNegRange}
+                ruler showLabels
+                formatLabel={(v) => v.toFixed(1)}
                 trackColor="#dde3ea"
                 rangeColor="#4a9a4a"
                 thumbColor="#ffffff"
                 style={{ width: "100%" }}
               />
-            );
-          })()}
-        </DemoSection>
+            </DemoSection>
 
-        {/* 5 ── Negative / positive range */}
-        <DemoSection
-          id="scale-negative"
-          title="Negative and positive range"
-          description="The ruler works across negative ranges. step={0.1} gives 20 auto ticks between -1 and 1."
-          meta={<strong>onInput: &nbsp;{negRange.min.toFixed(1)} &nbsp; {negRange.max.toFixed(1)}</strong>}
-          code={`<RangeSlider
-  min={-1} max={1} step={0.1}
-  defaultValue={{ min: -0.5, max: 0.5 }}
-  onChange={setNegRange}
-  ruler
-  showLabels
-  formatLabel={(v) => v.toFixed(1)}
-/>`}
-        >
-          <RangeSlider
-            min={-1} max={1} step={0.1}
-            defaultValue={{ min: -0.5, max: 0.5 }}
-            onChange={setNegRange}
-            ruler
-            showLabels
-            formatLabel={(v) => v.toFixed(1)}
-            trackColor="#dde3ea"
-            rangeColor="#4a9a4a"
-            thumbColor="#ffffff"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
-
-        {/* 6 ── Step-only snapping */}
-        <DemoSection
-          id="scale-steponly"
-          title="Range slider with step snapping"
-          description="step={5} snaps the thumbs to multiples of 5. The ruler tick count auto-adjusts to the step size."
-          meta={<strong>onInput: &nbsp;{stepRange.min} &nbsp; {stepRange.max}</strong>}
-          code={`<RangeSlider
+            <DemoSection
+              id="scale-steponly"
+              title="Range slider with step snapping"
+              description="step={5} snaps the thumbs to multiples of 5. The ruler tick count auto-adjusts."
+              meta={<strong>onInput: {stepRange.min} – {stepRange.max}</strong>}
+              code={`<RangeSlider
   min={0} max={100} step={5}
   defaultValue={{ min: 30, max: 60 }}
   onChange={setStepRange}
-  ruler
-  showLabels
+  ruler showLabels
 />`}
-        >
-          <RangeSlider
-            min={0} max={100} step={5}
-            defaultValue={{ min: 30, max: 60 }}
-            onChange={setStepRange}
-            ruler
-            showLabels
-            trackColor="#dde3ea"
-            rangeColor="#4a9a4a"
-            thumbColor="#ffffff"
-            style={{ width: "100%" }}
-          />
-        </DemoSection>
-      </div>
-
-      {/* ══════════════════════════════════════════════════════════
-          THEMES
-      ══════════════════════════════════════════════════════════ */}
-      <div className="examples-layout" id="themes">
-        <SectionHeader
-          tag="Feature"
-          title="Themes"
-          description='Pass theme="default | material | neumorphic | dark" to any component.'
-        />
-
-        <section className="demo-section demo-section--themes" id="theme-grid">
-          <div className="demo-copy">
-            <h3>Four built-in themes</h3>
-            <p>Each theme ships with its own colour tokens and focus-visible ring. All tokens can be further overridden with trackColor, rangeColor, and thumbColor.</p>
+            >
+              <RangeSlider
+                min={0} max={100} step={5}
+                defaultValue={{ min: 30, max: 60 }}
+                onChange={setStepRange}
+                ruler showLabels
+                trackColor="#dde3ea"
+                rangeColor="#4a9a4a"
+                thumbColor="#ffffff"
+                style={{ width: "100%" }}
+              />
+            </DemoSection>
           </div>
-          <div className="demo-panel demo-panel--themes">
-            <div className="theme-row">
-              {[
-                { theme: "default",    label: "Default",    state: tDefault,  setter: setTDefault  },
-                { theme: "material",   label: "Material",   state: tMaterial, setter: setTMaterial },
-                { theme: "neumorphic", label: "Neumorphic", state: tNeum,     setter: setTNeum     },
-                { theme: "dark",       label: "Dark",       state: tDark,     setter: setTDark     },
-              ].map(({ theme, label, state, setter }) => (
-                <div className={`theme-card theme-card--${theme}`} key={theme}>
-                  <span className="theme-card__name">{label}</span>
-                  <RangeSlider
-                    min={0} max={100}
-                    value={state}
-                    onChange={setter}
-                    showTooltip showLabels
-                    theme={theme}
-                    style={{ width: "100%" }}
-                  />
-                  <span className="theme-card__value">
-                    {state.min} – {state.max}
-                  </span>
+
+          {/* ══ THEMES ═════════════════════════════════════════ */}
+          <div className="examples-layout" id="themes">
+            <SectionHeader
+              tag="Feature"
+              title="Themes"
+              description='Pass theme="default | material | neumorphic | dark" to any component.'
+            />
+
+            <section className="demo-section" id="theme-grid">
+              <div className="demo-left">
+                <h3 className="demo-title">Four built-in themes</h3>
+                <p className="demo-desc">
+                  Each theme ships with its own colour tokens and focus-visible ring.
+                  All tokens can be further overridden with trackColor, rangeColor, and thumbColor.
+                </p>
+                <div className="demo-panel">
+                  <div className="theme-row">
+                    {[
+                      { theme: "default",    label: "Default",    state: tDefault,  setter: setTDefault  },
+                      { theme: "material",   label: "Material",   state: tMaterial, setter: setTMaterial },
+                      { theme: "neumorphic", label: "Neumorphic", state: tNeum,     setter: setTNeum     },
+                      { theme: "dark",       label: "Dark",       state: tDark,     setter: setTDark     },
+                    ].map(({ theme, label, state, setter }) => (
+                      <div className={`theme-card theme-card--${theme}`} key={theme}>
+                        <span className="theme-card__name">{label}</span>
+                        <RangeSlider
+                          min={0} max={100}
+                          value={state}
+                          onChange={setter}
+                          showTooltip showLabels
+                          theme={theme}
+                          style={{ width: "100%" }}
+                        />
+                        <span className="theme-card__value">
+                          {state.min} – {state.max}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
                 </div>
-              ))}
-            </div>
-          </div>
-          <CodeBlock>{`// Any component accepts a theme prop
-<RangeSlider theme="dark"       ... />
-<SingleSlider theme="material"  ... />
+              </div>
+              <CodeBlock>{`// Any component accepts a theme prop
+<RangeSlider theme="dark"          ... />
+<SingleSlider theme="material"     ... />
 <CircularSlider theme="neumorphic" ... />`}</CodeBlock>
-        </section>
-      </div>
+            </section>
+          </div>
 
-    </main>
+        </main>
+
+        {/* ── RIGHT SIDEBAR ──────────────────────────────────── */}
+        <Sidebar activeId={activeId} />
+      </div>
+    </div>
   );
 }

--- a/src/components/MultiPointSlider.tsx
+++ b/src/components/MultiPointSlider.tsx
@@ -83,7 +83,7 @@ const MultiPointSlider = memo<MultiPointSliderProps>(function MultiPointSlider({
     <div
       role="group"
       aria-labelledby={groupId}
-      className={cx("mrs-slider", `mrs-theme-${theme}`, { "mrs-slider--disabled": disabled }, className)}
+      className={cx("mrs-slider", `mrs-theme-${theme}`, { "mrs-slider--disabled": disabled, "mrs-slider--with-tooltip": showTooltip }, className)}
       style={{ ...cssVars, ...style }}
     >
       <span id={groupId} className="mrs-sr-only">

--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -140,7 +140,7 @@ const RangeSlider = memo<RangeSliderProps>(function RangeSlider({
       className={cx(
         "mrs-slider",
         `mrs-theme-${theme}`,
-        { "mrs-slider--disabled": disabled },
+        { "mrs-slider--disabled": disabled, "mrs-slider--with-tooltip": showTooltip },
         className,
       )}
       style={{ ...cssVars, ...style }}

--- a/src/components/SingleSlider.tsx
+++ b/src/components/SingleSlider.tsx
@@ -82,7 +82,7 @@ const SingleSlider = memo<SingleSliderProps>(function SingleSlider({
 
   return (
     <div
-      className={cx("mrs-slider", `mrs-theme-${theme}`, { "mrs-slider--disabled": disabled }, className)}
+      className={cx("mrs-slider", `mrs-theme-${theme}`, { "mrs-slider--disabled": disabled, "mrs-slider--with-tooltip": showTooltip }, className)}
       style={{ ...cssVars, ...style }}
       aria-disabled={disabled}
     >

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -95,6 +95,14 @@
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
+  /* Offset added to thumb top when tooltip container is present */
+  --mrs-tooltip-h: 0px;
+}
+
+/* When showTooltip=true the 26px .mrs-tooltips container sits above the track,
+   shifting the track down — thumb top must compensate for the same offset. */
+.mrs-slider--with-tooltip {
+  --mrs-tooltip-h: 26px;
 }
 
 /* ── Track ──────────────────────────────────────────────────── */
@@ -125,7 +133,7 @@
   -moz-appearance: none;
   appearance: none;
   position: absolute;
-  top: calc(12px - var(--mrs-thumb-size) / 2 + var(--mrs-track-h) / 2);
+  top: calc(12px + var(--mrs-tooltip-h) - var(--mrs-thumb-size) / 2 + var(--mrs-track-h) / 2);
   left: 0;
   width: 100%;
   height: var(--mrs-thumb-size);
@@ -208,6 +216,8 @@
   pointer-events: none;
   /* Allow push-apart tooltips to escape the container bounds */
   overflow: visible;
+  /* Render above the absolutely-positioned thumb inputs (z-index 3-5) */
+  z-index: 10;
 }
 
 .mrs-tooltip {


### PR DESCRIPTION
The .mrs-input thumb top calculation assumed the track sits immediately after the 12px padding. When showTooltip=true the 26px .mrs-tooltips container is inserted before the track in normal flow, shifting the track down but leaving the thumb in the wrong position — causing it to float above the track and overlap the tooltip.

Added --mrs-tooltip-h CSS variable (0px by default, 26px via .mrs-slider--with-tooltip) to compensate, updated .mrs-input top to include the offset, and set z-index:10 on .mrs-tooltips so it always renders above the thumb inputs. Applied the new class in RangeSlider, SingleSlider, and MultiPointSlider when showTooltip is true.

Also redesigned the example page with a sticky navbar, hero section, and a right sidebar with scroll-spy navigation organised by component.